### PR TITLE
Improve type stability with JET analysis; fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 *SDiagonalizability.jl* packages the first non-naïve deterministic algorithm to minimize the *S*-bandwidth of a quantum network (or, to be more precise, its graph representation), written in Julia. Given some finite *S* &isin; **Z**<sup>*n*</sup>, the *S*-bandwidth of an (undirected) graph *G* with Laplacian *L(G)* &isin; **R**<sup>*n*&times;*n*</sup> is the minimum *k* &ge; 1 such that *L(G)* = *PDP*<sup>-1</sup> for some diagonal *D* &isin; **R**<sup>*n*&times;*n*</sup> and *P* &isin; **S**<sup>*n*&times;*n*</sup> with [*P<sup>T</sup>P*]<sub>*ij*</sub> = 0 whenever |*i* - *j*| &ge; *k*. For specific choices of *S* (namely *S* = {-1,1} and *S* = {-1,0,1}), a quantum network's *S*-bandwidth has been shown to be an indicator of high state transfer fidelity due to automorphic properties of its graph representation.
 
-**CURRENTLY UNDER DEVELOPMENT:** We are aiming to release the initial stable version of *SDiagonalizability.jl* in mid-June 2025. The current version is a work-in-progress, with the main `SDiagonalizability` module not yet functional and comprehensive documentation/tests not yet available.
+**CURRENTLY UNDER DEVELOPMENT:** We aim to release the initial stable version of *SDiagonalizability.jl* in mid-June 2025. The current version is a work-in-progress, with the main `SDiagonalizability` module not yet functional and comprehensive documentation/tests not yet available.
 
 ## Credits
 

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -121,3 +121,7 @@ function _pot_nonkernel_eigvecs_01neg(n::Integer)
         )
     )
 end
+
+# TODO: Add comments here
+Base.eltype(::typeof(_pot_kernel_eigvecs_01neg(0))) = Vector{Int}
+Base.eltype(::typeof(_pot_nonkernel_eigvecs_01neg(0))) = Vector{Int}

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -10,6 +10,18 @@ struct SpectrumIntegralResult
     matrix::Matrix{Int}
     spectrum_integral::Bool
     multiplicities::Union{Nothing,OrderedDict{Int,Int}}
+
+    function SpectrumIntegralResult(
+        matrix::Matrix{Int},
+        spectrum_integral::Bool,
+        multiplicities::Union{Nothing,OrderedDict{Int,Int}},
+    )
+        if spectrum_integral && !isnothing(multiplicities)
+            throw(ArgumentError("TODO: Write here"))
+        end
+
+        return new(matrix, spectrum_integral, multiplicities)
+    end
 end
 
 struct _Eigenspace01Neg
@@ -34,8 +46,14 @@ function Base.getproperty(obj::_LaplacianSpectrum01Neg, name::Symbol)
 
     if name != :eigspaces_01neg && name in fieldnames(_LaplacianSpectrum01Neg)
         value = getfield(obj, name)
-    elseif obj.diagonalizable_01neg
+    elseif getfield(obj, :diagonalizable_01neg)
         eigspaces_01neg = getfield(obj, :eigspaces_01neg)
+
+        #= For compiler inference during static analysis. We choose to assert rather than
+        throw an error because this struct is not part of the public API; hence, any failure
+        to meet this condition indicates a developer error. =#
+        @assert !isnothing(eigspaces_01neg)
+
         name == :multiplicities && (name = :dimension)
         value = OrderedDict(
             eigval => getfield(eigspace, name) for (eigval, eigspace) in eigspaces_01neg
@@ -50,7 +68,7 @@ end
 function check_spectrum_integrality(X::AbstractMatrix{<:Integer})
     X_copy = Matrix{Int}(X) # Avoid shared mutability and cast to `Matrix{Int}`
     eigvals_float = eigvals(X_copy)
-    eigvals_int = round.(Int, real.(eigvals_float))
+    eigvals_int = Int.(round.(real.(eigvals_float)))
     spectrum_integral = isapprox(eigvals_float, eigvals_int)
 
     # Sort first by ascending multiplicity then by ascending eigenvalue
@@ -64,12 +82,17 @@ function check_spectrum_integrality(X::AbstractMatrix{<:Integer})
 end
 
 function _extract_independent_cols(E::AbstractMatrix{<:Integer})
+    # Cast to a dense floating-point matrix to enable optimizations in `LinearAlgebra.qr`
+    E_float = Matrix{Float64}(E)
+
     # Factorize `E = QR` for some orthogonal matrix `Q` and upper triangular matrix `R`
-    F = qr(E, ColumnNorm())
+    F = qr(E_float, ColumnNorm())
     pivots = F.p # The first `rank(E)` pivots correspond to independent columns of `E`
     ortho_coefs = diag(F.R) # Scaling factors of the columns of the `Q` matrix
-    tol = rank_rtol(E) * maximum(abs, ortho_coefs)
+
+    tol = rank_rtol(E_float) * maximum(abs, ortho_coefs)
     r = count(x -> abs(x) > tol, ortho_coefs) # The rank of `E` within floating-point error
+
     return E[:, pivots[1:r]] # A largest independent subset of the columns of `E`
 end
 
@@ -219,15 +242,16 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
     # The kernel is simpler and handled differently from the other eigenspaces
     if multiplicities[0] == 1 # The all-ones vector spans the kernel
         eigvecs_01neg[0] = ones(Int, n, 1)
-    else # Check all {-1,0,1}-vectors in ℝⁿ, unique up to span 
+    else # Check all {-1,0,1}-vectors in ℝⁿ, unique up to span
+        # TODO: Multithread
         eigvecs_01neg[0] = hcat(
             Iterators.filter(v -> iszero(L * v), _pot_kernel_eigvecs_01neg(n))...
         )
     end
 
-    # TODO: Multithread this; lazy evaluation means speed will become an issue before memory
+    # TODO: Multithread
     # Now fill up the remaining (non-kernel) eigenspaces
-    for v in _pot_kernel_eigvecs_01neg(n)
+    for v in _pot_nonkernel_eigvecs_01neg(n)
         for eigval in eigvals_nonzero
             if L * v == eigval * v
                 append!(eigvecs_01neg[eigval], v)

--- a/test/static_analysis/jet.jl
+++ b/test/static_analysis/jet.jl
@@ -17,7 +17,7 @@ using SDiagonalizability
     @show length(jet_reports)
     @show rep
 
-    @test length(jet_reports) <= 30
+    @test length(jet_reports) < 20
     @test_broken length(jet_reports) == 0
 end
 


### PR DESCRIPTION
Added a `Base.eltype` override to the eigenvector generators in `src/eigenvector_generation.jl`. Made an inner constructor to the (public) `SpectrumIntegralResult` struct in `src/laplacian_spectra.jl` to filter out unintended input. Added an assert statement to the `Base.getproperty` override of the (private) `_LaplacianSpectrum01Neg` struct in the same file f
or compiler inference with JET, and replaced a recursive `getproperty` call with `getfield`. Converted matrix to dense flo
at array in `_extract_independent_cols` for type stability/performance with `LinearAlgebra.qr` (and added whitespace).

Finally, tightened the bound on the number of JET reports to 20 (exclusive)! Still quite a few JET reports/warning
s to go fix, but many of them are stale/artifacts that can remain.

(Slightly unrelated, but also updated 'We are aiming to release...' to 'We aim to release...' in the README for brevity.)