### PR TITLE
Cover every binding with a (perhaps WIP) docstring

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,7 @@ DocMeta.setdocmeta!(
     SDiagonalizability, :DocTestSetup, :(using SDiagonalizability); recursive=true
 )
 
-bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style=:numeric)
+bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style=:alpha)
 
 makedocs(;
     modules=[SDiagonalizability],
@@ -24,7 +24,11 @@ makedocs(;
         assets=String[],
     ),
     plugins=[bib],
-    pages=["Home" => "index.md"],
+        pages=[
+        "Home" => "index.md",
+        "Public API" => "public_api.md",
+        "Private API" => "private_api.md",
+    ],
 )
 
 deploydocs(; repo="github.com/GraphQuantum/SDiagonalizability.jl", devbranch="main")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,16 +2,20 @@
 CurrentModule = SDiagonalizability
 ```
 
-# SDiagonalizability
+# SDiagonalizability.jl
 
-Documentation for [SDiagonalizability](https://github.com/GraphQuantum/SDiagonalizability.jl).
+*SDiagonalizability.jl* packages the first non-naïve deterministic algorithm to minimize the ``S``-bandwidth of a quantum network (or, to be more precise, its graph representation), written in Julia. Given some finite ``S \in \mathbb{Z}^n``, the ``S``-bandwidth of an (undirected) graph ``G`` with Laplacian ``L(G) \in \mathbb{R}^n`` is the minimum ``k \ge 1`` such that ``L(G) = PDP^{-1}`` for some diagonal ``D \in \mathbb{R}^{n \times n}`` and ``P \in S^{n \times n}`` with ``P^T P_{ij} = 0`` whenever ``|i - j| \ge k``. For specific choices of ``S`` (namely ``S = \{-1,1\}`` and ``S = \{-1,0,1\}``), a quantum network's ``S``-bandwidth has been shown to be an indicator of high state transfer fidelity due to automorphic properties of its graph representation.
+
+!!! important "CURRENTLY UNDER DEVELOPMENT"
+    We aim to release the initial stable version of *SDiagonalizability.jl* in mid-June 2025. The current version is a work-in-progress, with the main `SDiagonalizability` module not yet functional and comprehensive documentation/tests not yet available.
+
+## Credits
+
+Created by [Luis M. B. Varona](https://github.com/Luis-Varona), [Dr. Nathaniel Johnston](https://github.com/nathanieljohnston), and Dr. Sarah Plosker.
+
+Insights from [Benjamin Talbot](https://github.com/Benjamin-Talbot), [Logan Pipes](https://github.com/logan-pipes), and [Dr. Liam Keliher](https://github.com/lkeliher) are gratefully acknowledged.
+
+## Index
 
 ```@index
-```
-
-```@autodocs
-Modules = [SDiagonalizability]
-```
-
-```@bibliography
 ```

--- a/docs/src/private_api.md
+++ b/docs/src/private_api.md
@@ -1,0 +1,24 @@
+```@meta
+CurrentModule = SDiagonalizability
+```
+
+# SDiagonalizability.jl – Private API
+
+Documentation for [SDiagonalizability](https://github.com/GraphQuantum/SDiagonalizability.jl)'s private API.
+
+!!! note
+    The following documentation covers only the private API of the package. For public details, see the [public API documentation](public_api.md).
+
+!!! warning
+    The following bindings are internal; they may change or be removed in future versions.
+
+```@autodocs
+Modules = [SDiagonalizability]
+Public = false
+```
+
+## References
+
+```@bibliography
+Pages = [@__FILE__]
+```

--- a/docs/src/public_api.md
+++ b/docs/src/public_api.md
@@ -1,0 +1,21 @@
+```@meta
+CurrentModule = SDiagonalizability
+```
+
+# SDiagonalizability.jl – Public API
+
+Documentation for [SDiagonalizability](https://github.com/GraphQuantum/SDiagonalizability.jl)'s public API.
+
+!!! note
+    The following documentation covers only the public API of the package. For internal details, see the [private API documentation](private_api.md).
+
+```@autodocs
+Modules = [SDiagonalizability]
+Private = false
+```
+
+## References
+
+```@bibliography
+Pages = [@__FILE__]
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -33,6 +33,17 @@
   url = "https://doi.org/10.1016/j.laa.2024.10.016",
 }
 
+@article{Maf14,
+  title = "The Bandwidths of a Matrix. A Survey of Algorithms",
+  author = "Mafteiu-Scai, Liviu Octavian",
+  journal = "*Annals of West University of Timisoara - Mathematics and Computer Science*",
+  year = 2014,
+  volume = "52",
+  number = "2",
+  pages = "183--223",
+  url = "https://doi.org/10.2478/awutm-2014-0019",
+}
+
 @misc{numpy25,
   title = "{numpy.linalg.matrix_rank}",
   author = "{NumPy Developers}",

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -55,7 +55,7 @@
 
 @misc{Slo25,
   title = "a(n) = (3^n - 1)/2",
-  author = "{N. J. A. Sloane}",
+  author = "Sloane, Neil James Alexander",
   howpublished = "Entry A003462 in *The On-Line Encyclopedia of Integer Sequences*",
   year = 2025,
   url = "https://oeis.org/A003462",
@@ -64,7 +64,7 @@
 
 @article{VL20,
   title = "A Primer on Laplacian Dynamics in Directed Graphs",
-  author = "{J. J. P. Veerman} and Lyons, Robert",
+  author = "Veerman, J. J. P. and Lyons, Robert",
   journal = "*Nonlinear Phenomena in Complex Systems*",
   year = 2020,
   volume = "23",

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -4,6 +4,23 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
+"""
+    SDiagonalizability
+
+A dynamic algorithm to test a graph for *S*-diagonalizability and minimize its *S*-bandwidth.
+
+*SDiagonalizability.jl* packages the first non-naïve deterministic algorithm to minimize the
+*S*-bandwidth of a quantum network (or, to be more precise, its graph representation),
+written in Julia. Given some finite *S* ∈ **Z**ⁿ, the *S*-bandwidth of an (undirected) graph
+*G* with Laplacian *L(G)* ∈ **R**ⁿˣⁿ is the minimum *k* ≥ 1 such that *L(G)* = *PDP*⁻¹ for
+some diagonal *D* ∈ **R**ⁿˣⁿ and *P* ∈ *S*ⁿˣⁿ with [*P*ᵀ*P*]ᵢⱼ = 0 whenever |*i* - *j*| ≥
+*k*. For specific choices of *S* (namely *S* = {-1,1} and *S* = {-1,0,1}), a quantum
+network's *S*-bandwidth has been shown to be an indicator of high state transfer fidelity
+due to automorphic properties of its graph representation.
+
+[Full documentation](https://graphquantum.github.io/SDiagonalizability.jl/dev/) is available
+for the latest development version of this package.
+"""
 module SDiagonalizability
 
 using Graphs

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -14,7 +14,10 @@ using DataStructures: OrderedDict, counter
 using ElasticArrays: ElasticMatrix
 using MolecularGraph: subgraph_monomorphisms
 
+# TODO: Create and include `precompile_workload.jl`
 using PrecompileTools: @setup_workload, @compile_workload
+
+# TODO: Check if we really need the module preface for cross-referencing private functions
 
 include("utils.jl")
 include("factories/laplacian_types.jl")
@@ -25,7 +28,11 @@ include("laplacian_spectra.jl")
 include("basis_search.jl")
 include("s_bandwidth.jl")
 
+# Exports from `laplacian_spectra.jl`
+export LaplacianSpectrum01Neg, laplacian_spectra_01neg
 export SpectrumIntegralResult, check_spectrum_integrality
-# TODO: Add exports from `s_bandwidth.jl`
+
+# Exports from `s_bandwidth.jl`
+export s_bandwidth
 
 end

--- a/src/basis_search.jl
+++ b/src/basis_search.jl
@@ -6,11 +6,21 @@
 
 # TODO: Add comments and docstrings to this file
 
+"""
+    mutable struct _QOBasisSearchNodeData
+
+TODO: Write here
+"""
 mutable struct _QOBasisSearchNodeData
     component::UInt8
     vertex_degree::UInt8
 end
 
+"""
+    _find_k_orthogonal_basis(column_space, column_rank, k)
+
+TODO: Write here
+"""
 function _find_k_orthogonal_basis(
     column_space::AbstractMatrix{Int}, column_rank::Int, k::Int
 )
@@ -18,10 +28,20 @@ function _find_k_orthogonal_basis(
     return _find_basis_with_property(column_space, column_rank, prop)
 end
 
+"""
+    _find_basis_with_property(column_space, column_rank, prop::_KOrthogonality)
+
+TODO: Write here
+"""
 function _find_basis_with_property(::AbstractMatrix{Int}, ::Int, prop::_KOrthogonality)
     throw(NotImplementedError(_find_basis_with_property, typeof(prop), _KOrthogonality))
 end
 
+"""
+    _find_basis_with_property(column_space, column_rank, prop:::_Orthogonality)
+
+TODO: Write here
+"""
 function _find_basis_with_property(
     column_space::AbstractMatrix{Int}, column_rank::Int, prop::_Orthogonality
 )
@@ -37,6 +57,11 @@ function _find_basis_with_property(
     return nothing
 end
 
+"""
+    _find_basis_with_property(column_space, column_rank, prop::_QuasiOrthogonality)
+
+TODO: Write here
+"""
 function _find_basis_with_property(
     column_space::AbstractMatrix{Int}, column_rank::Int, prop::_QuasiOrthogonality
 )
@@ -59,8 +84,12 @@ function _find_basis_with_property(
     return nothing
 end
 
-# TODO: For this function in particular, comments appear to be complete but are not. Also,
-# note that we assume `k < column_rank` (or else just use the QR results). Add assert or no?
+# TODO: Note that we assume `k < column_rank` (else, just use QR results). Add assert or no?
+"""
+    _find_basis_with_property(column_space, column_rank, prop::_WeakOrthogonality)
+
+TODO: Write here
+"""
 function _find_basis_with_property(
     column_space::AbstractMatrix{Int}, column_rank::Int, prop::_WeakOrthogonality
 )
@@ -80,14 +109,25 @@ function _find_basis_with_property(
         add_edge!(G, i, i + d)
     end
 
+    #= Every collection of `k` or less vectors is `k`-orthogonal, so we can start searching
+    from `k`-combinations of our columns. =#
     for root_indices in combinations(1:num_columns, k)
+        # Avoid reallocations by taking a view
         partial_basis = view(column_space, :, root_indices)
+
+        #= Bandwidth minimzation of the Gram matrix of our candidate basis vectors is
+        equivalent to testing the resulting graph for subgraph monomorphism to `G`. (We do,
+        however, plan to replace this with a more specialized algorithm in the future.) =#
         ortho_graph_compl_adjacency = .!iszero.(partial_basis' * partial_basis)
         ortho_graph_compl_adjacency[diagind(ortho_graph_compl_adjacency)] .= false
 
+        #= Before running a subgraph monomorphism search, we can filter out (partial) bases
+        by [TODO: Write here] =#
         if all(sum(ortho_graph_compl_adjacency; dims=1) .<= 2k - 2)
             H = Graph(column_rank) # Initialize the empty graph on `column_rank` vertices
 
+            #= The aforementioned "resulting graph" from the Gram matrix is constructed by
+            [TODO: Write here] =#
             for i in 1:(k - 1), j in (i + 1):k
                 ortho_graph_compl_adjacency[i, j] && add_edge!(H, i, j)
             end
@@ -95,13 +135,21 @@ function _find_basis_with_property(
             basis_indices = _find_basis_indices(
                 root_indices, column_space, column_rank, G, H, prop
             )
+            # If there is no monomorphism, terminate searching this branch of the tree
             isnothing(basis_indices) || return column_space[:, basis_indices]
         end
     end
 
+    #= If all children are searched/pruned and basis is found, return `nothing` to signal
+    that this branch should be pruned. =#
     return nothing
 end
 
+"""
+    _find_basis_indices(curr_indices, column_space, column_rank, prop::_Orthogonality)
+
+TODO: Write here
+"""
 function _find_basis_indices(
     curr_indices::AbstractVector{Int},
     column_space::AbstractMatrix{Int},
@@ -129,6 +177,18 @@ function _find_basis_indices(
     return nothing
 end
 
+"""
+    _find_basis_indices(
+        curr_indices,
+        column_space,
+        column_rank,
+        nodes,
+        union_find,
+        prop::_QuasiOrthogonality,
+    )
+
+TODO: Write here
+"""
 function _find_basis_indices(
     curr_indices::AbstractVector{Int},
     column_space::AbstractMatrix{Int},
@@ -187,7 +247,8 @@ function _find_basis_indices(
 
     if depth == column_rank
         basis_indices = copy(curr_indices)
-        # TODO: Note about nice ordering
+        #= Sorting within each connected component of the union-find structure
+        yields a "nicer," more natural ordering. =#
         order = collect(Iterators.flatmap(sort, values(union_find)))
         return basis_indices[order]
     end
@@ -210,6 +271,18 @@ function _find_basis_indices(
     return nothing
 end
 
+"""
+    _find_basis_indices(
+        curr_indices,
+        column_space,
+        column_rank,
+        G::Graph,
+        H::Graph,
+        prop::_WeakOrthogonality,
+    )
+
+TODO: Write here
+"""
 function _find_basis_indices(
     curr_indices::AbstractVector{Int},
     column_space::AbstractMatrix{Int},
@@ -242,7 +315,7 @@ function _find_basis_indices(
 
     if depth == column_rank
         basis_indices = copy(curr_indices)
-        # The monomorphism mapping gives a k-orthogonal column ordering
+        # The monomorphism mapping gives a `k`-orthogonal column ordering
         order = last.(sort(collect(monomorphism[1])))
         return basis_indices[order]
     end

--- a/src/basis_search.jl
+++ b/src/basis_search.jl
@@ -115,7 +115,7 @@ function _find_basis_with_property(
         # Avoid reallocations by taking a view
         partial_basis = view(column_space, :, root_indices)
 
-        #= Bandwidth minimzation of the Gram matrix of our candidate basis vectors is
+        #= Bandwidth minimization of the Gram matrix of our candidate basis vectors is
         equivalent to testing the resulting graph for subgraph monomorphism to `G`. (We do,
         however, plan to replace this with a more specialized algorithm in the future.) =#
         ortho_graph_compl_adjacency = .!iszero.(partial_basis' * partial_basis)

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -24,7 +24,7 @@ independence between all generated vectors.
 - `DomainError`: if `n` is negative.
 
 # Examples
-Generate all potential kernel eigenvectors for an order `2` Laplacian matrix:
+Generate all potential kernel eigenvectors for an order `3` Laplacian matrix:
 ```jldoctest; setup = :(using SDiagonalizability)
 julia> hcat(SDiagonalizability._pot_kernel_eigvecs_01neg(3)...)
 3×13 Matrix{Int64}:

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -38,11 +38,12 @@ The number of potential kernel eigenvectors (unique up to span) for an order `n`
 matrix is given by `(3ⁿ - 1) / 2`. See also the relevant OEIS sequence [Slo25](@cite).
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
-noting that eigenvector generation (and subsequent processing by `_laplacian_spectra_01neg`)
-is one of two major bottlenecks in the overall *S*-bandwidth minimization algorithm. Given
-how much potential there is for optimization in this piece of code, we thus prioritize
-performance over readability in this particular case, making every effort to include inline
-comments wherever clarification may be needed.
+noting that eigenvector generation (and subsequent processing by
+[`laplacian_spectra_01neg`](@ref)) is one of two major bottlenecks in
+the overall *S*-bandwidth minimization algorithm. Given how much potential there is for
+optimization in this piece of code, we thus prioritize performance over readability in this
+particular case, making every effort to include inline comments wherever clarification may
+be needed.
 """
 function _pot_kernel_eigvecs_01neg(n::Integer)
     n < 0 && throw(DomainError(n, "Laplacian order must be non-negative"))
@@ -117,11 +118,12 @@ Laplacian matrix is, by non-trivial combinatorial arguments, equal to the number
 all Motzkin paths of length `n`. See also the relevant OEIS sequence [Deu25](@cite).
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
-noting that eigenvector generation (and subsequent processing by `_laplacian_spectra_01neg`)
-is one of two major bottlenecks in the overall *S*-bandwidth minimization algorithm. Given
-how much potential there is for optimization in this piece of code, we thus prioritize
-performance over readability in this particular case, making every effort to include inline
-comments wherever clarification may be needed.
+noting that eigenvector generation (and subsequent processing by
+[`laplacian_spectra_01neg`](@ref)) is one of two major bottlenecks in
+the overall *S*-bandwidth minimization algorithm. Given how much potential there is for
+optimization in this piece of code, we thus prioritize performance over readability in this
+particular case, making every effort to include inline comments wherever clarification may
+be needed.
 """
 function _pot_nonkernel_eigvecs_01neg(n::Integer)
     n < 0 && throw(DomainError(n, "Laplacian order must be non-negative"))

--- a/src/factories/laplacian_types.jl
+++ b/src/factories/laplacian_types.jl
@@ -10,41 +10,37 @@
 An abstract type representing a classified Laplacian matrix of an undirected graph.
 
 # Interface
-Concrete subtypes of [`SDiagonalizability._TypedLaplacian`](@ref) **must** implement the
-following fields:
+Concrete subtypes of [_TypedLaplacian`](@ref) **must** implement the following fields:
 - `matrix::Matrix{Int}`: the Laplacian matrix of the graph.
 
 # Subtypes
-- [`SDiagonalizability._NullGraphLaplacian`](@ref): a Laplacian wrapper for the (unique)
-    graph with no nodes.
-- [`SDiagonalizability._EmptyGraphLaplacian`](@ref): a Laplacian wrapper for any graph with
-    no edges on `n ≥ 1` nodes.
-- [`SDiagonalizability._CompleteGraphLaplacian`](@ref): a Laplacian wrapper for any graph on
-    `n ≥ 2` nodes where every pair of nodes is connected by an edge and all edges possess
-    the same weight.
-- [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref): a Laplacian wrapper for any graph
-    on `n ≥ 3` nodes with no particular strcuture of relevance in the context of
-    investigating `{-1,0,1}`-spectra.
+- [_NullGraphLaplacian`](@ref): a Laplacian wrapper for the (unique) graph with no nodes.
+- [`_EmptyGraphLaplacian`](@ref): a Laplacian wrapper for any graph with no edges on `n ≥ 1`
+    nodes.
+- [`_CompleteGraphLaplacian`](@ref): a Laplacian wrapper for any graph on `n ≥ 2` nodes
+    where every pair of nodes is connected by an edge and all edges possess the same weight.
+- [`_ArbitraryGraphLaplacian`](@ref): a Laplacian wrapper for any graph on `n ≥ 3` nodes
+    with no particular strcuture of relevance in the context of investigating
+    `{-1,0,1}`-spectra.
 
 # Notes
-Given that this type and all its subtypes are privately encapsulated within the
-[`SDiagonalizability`](@ref) module, we expect [`SDiagonalizability._TypedLaplacian`](@ref)
-instances to be created exclusively via the
-[`SDiagonalizability._cast_to_typed_laplacian`](@ref) factory function, which copies each
-input matrix to avoid shared mutability and converts it to a `Matrix{Int}` in the process.
-Therefore, it is safe to restrict the type of `matrix` field (in each concrete subtype) to
-`Matrix{Int}` in lieu of the more generic `AbstractMatrix{<:Integer}`. This decision may
-contribute marginal performance benefits via reduced type complexity and is highly unlikely
-to cause any issues (as this type is never to be exported to the public API). It also serves
-as an additional safeguard against directly passing a (wrongly typed) matrix to a subtype's
-constructor rather than calling [`SDiagonalizability._cast_to_typed_laplacian`](@ref).
+Given that this type and all its subtypes are privately encapsulated, we expect
+[`_TypedLaplacian`](@ref) instances to be created exclusively via the
+[`_cast_to_typed_laplacian`](@ref) factory function, which copies each input matrix to avoid
+shared mutability and converts it to a `Matrix{Int}` in the process. Therefore, it is safe
+to restrict the type of `matrix` field (in each concrete subtype) to `Matrix{Int}` in lieu
+of the more generic `AbstractMatrix{<:Integer}`. This decision may contribute marginal
+performance benefits via reduced type complexity and is highly unlikely to cause any issues
+(as this type is never to be exported to the public API). It also serves as an additional
+safeguard against directly passing a (wrongly typed) matrix to a subtype's constructor
+rather than calling [`_cast_to_typed_laplacian`](@ref).
 
 On a related note, it seems prudent to discuss the intended use case of
-[`SDiagonalizability._TypedLaplacian`](@ref). The interface and its subtypes are meant to
-support [`SDiagonalizability._cast_to_typed_laplacian`](@ref). This factory, in turn,
-determines which algorithm [`laplacian_spectra_01neg`](@ref) is to implement when computing
-data on the Laplacian matrix of a given graph, as different types of graphs exhibit
-different spectral properties which we may exploit to improve performance.
+[`_TypedLaplacian`](@ref). The interface and its subtypes are meant to support
+[`_cast_to_typed_laplacian`](@ref). This factory, in turn, determines which algorithm
+[`laplacian_spectra_01neg`](@ref) is to implement when computing data on the Laplacian
+matrix of a given graph, as different types of graphs exhibit different spectral properties
+which we may exploit to improve performance.
 """
 abstract type _TypedLaplacian end
 
@@ -63,8 +59,8 @@ _NullGraphLaplacian <: _TypedLaplacian <: Any
 See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
 `{-1,0,1}`-spectral properties of this Laplacian type.
 
-See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
-seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
+justification for typing the `matrix` field as `Matrix{Int}` rather than
 `AbstractMatrix{<:Integer}`.
 """
 struct _NullGraphLaplacian <: _TypedLaplacian
@@ -85,14 +81,13 @@ _EmptyGraphLaplacian <: _TypedLaplacian <: Any
 
 # Notes
 We are confident in the assumption that `n` is at least `1` because the only graph on zero
-nodes is the null graph, which is handled by the
-[`SDiagonalizability._NullGraphLaplacian`](@ref) type.
+nodes is the null graph, which is handled by the [`_NullGraphLaplacian`](@ref) type.
 
 See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
 `{-1,0,1}`-spectral properties of this Laplacian type.
 
-See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
-seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
+justification for typing the `matrix` field as `Matrix{Int}` rather than
 `AbstractMatrix{<:Integer}`.
 """
 struct _EmptyGraphLaplacian <: _TypedLaplacian
@@ -114,17 +109,16 @@ A wrapper for the Laplacian of any uniformly weighted complete graph on `n ≥ 2
 _CompleteGraphLaplacian <: _TypedLaplacian <: Any
 
 # Notes
-The only graph on zero nodes is the null graph (handled by the
-[`SDiagonalizability._NullGraphLaplacian`](@ref) type) and the only graph on one node is an
-empty graph (handled by the [`SDiagonalizability._EmptyGraphLaplacian`](@ref) type), so we
-are confident in the assumption that `n ≥ 2` for any
-[`SDiagonalizability._CompleteGraphLaplacian`](@ref) instance.
+The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
+type) and the only graph on one node is an empty graph (handled by the
+[`_EmptyGraphLaplacian`](@ref) type), so we are confident in the assumption that `n ≥ 2` for
+any [`_CompleteGraphLaplacian`](@ref) instance.
 
 See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
 `{-1,0,1}`-spectral properties of this Laplacian type.
 
-See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
-seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
+justification for typing the `matrix` field as `Matrix{Int}` rather than
 `AbstractMatrix{<:Integer}`.
 """
 struct _CompleteGraphLaplacian <: _TypedLaplacian
@@ -146,19 +140,18 @@ of interest.
 _ArbitraryGraphLaplacian <: _TypedLaplacian <: Any
 
 # Notes
-The only graph on zero nodes is the null graph (handled by the
-[`SDiagonalizability._NullGraphLaplacian`](@ref) type), the only graph on one node is an
-empty graph (handled by the [`SDiagonalizability._EmptyGraphLaplacian`](@ref) type), and the
-only graphs on two nodes are an empty graph and a complete graph (handled by the
-[`SDiagonalizability._CompleteGraphLaplacian`](@ref) type), so we are confident in the
-assumption that `n ≥ 3` for any [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref)
+The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
+type), the only graph on one node is an empty graph (handled by the
+[`_EmptyGraphLaplacian`](@ref) type), and the only graphs on two nodes are an empty graph
+and a complete graph (handled by the [`_CompleteGraphLaplacian`](@ref) type), so we are
+confident in the assumption that `n ≥ 3` for any [`_ArbitraryGraphLaplacian`](@ref)
 instance.
 
 See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
 `{-1,0,1}`-spectral properties of this Laplacian type.
 
-See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
-seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
+justification for typing the `matrix` field as `Matrix{Int}` rather than
 `AbstractMatrix{<:Integer}`.
 """
 struct _ArbitraryGraphLaplacian <: _TypedLaplacian
@@ -168,17 +161,19 @@ end
 """
     _cast_to_typed_laplacian(L)
 
-Classify a Laplacian matrix and wrap it with [`SDiagonalizability._TypedLaplacian`](@ref).
+Classify the Laplacian matrix `L` and wrap it in a [`_TypedLaplacian`](@ref) object.
 
-`L` is classified based on any properties which may be exploited in computing data on its
-`{-1,0,1}`-spectrum. It is first verified that `L` is indeed a valid Laplacian matrix.
+It is first verified that `L` is indeed a Laplacian matrix by
+[`_assert_matrix_is_undirected_laplacian`](@ref), which throws a `DomainError` otherwise. It
+is then classified based on any properties which may be exploited in computing data on its
+`{-1,0,1}`-spectrum.
 
 # Arguments
 - `L::AbstractMatrix{<:Integer}`: the Laplacian matrix to classify.
 
 # Returns
 - `TL::_TypedLaplacian`: the Laplacian wrapped in a concrete
-    [`SDiagonalizability._TypedLaplacian`](@ref) subtype associated with the category of the
+    [`_TypedLaplacian`](@ref) subtype associated with the category of the
     graph represented by `L`. In the case of complete graphs, `TL` also contains data on the
     (necessarily uniform) weight of each edge.
 
@@ -257,13 +252,12 @@ true
 # Notes
 Right now, the possible types of Laplacian matrices (or, to be more precise, the graphs they
 represent) are:
-- [`SDiagonalizability._NullGraphLaplacian`](@ref): the (unique) graph with no nodes.
-- [`SDiagonalizability._EmptyGraphLaplacian`](@ref): any graph with no edges on `n ≥ 1`
-    nodes.
-- [`SDiagonalizability._CompleteGraphLaplacian`](@ref): any graph on `n ≥ 2` nodes where
-    every pair of nodes is connected by an edge and all edges possess the same weight.
-- [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref): any graph on `n ≥ 3` nodes with no
-    particular strcuture of relevance in the context of investigating `{-1,0,1}`-spectra.
+- [`_NullGraphLaplacian`](@ref): the (unique) graph with no nodes.
+- [`_EmptyGraphLaplacian`](@ref): any graph with no edges on `n ≥ 1` nodes.
+- [`_CompleteGraphLaplacian`](@ref): any graph on `n ≥ 2` nodes where every pair of nodes is
+    connected by an edge and all edges possess the same weight.
+- [`_ArbitraryGraphLaplacian`](@ref): any graph on `n ≥ 3` nodes with no particular
+    strcuture of relevance in the context of investigating `{-1,0,1}`-spectra.
 """
 function _cast_to_typed_laplacian(L::AbstractMatrix{<:Integer})
     #= Verify that `L` is symmetric (thus representing an undirected graph) and has zero row

--- a/src/factories/laplacian_types.jl
+++ b/src/factories/laplacian_types.jl
@@ -4,44 +4,285 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Add comments and docstrings to this file
+"""
+    abstract type _TypedLaplacian
 
-abstract type _TypedLaplacian <: AbstractMatrix{Int} end
+An abstract type representing a classified Laplacian matrix of an undirected graph.
 
-Base.size(L::_TypedLaplacian) = size(L.matrix)
-Base.getindex(L::_TypedLaplacian, i::Int, j::Int) = L.matrix[i, j]
-Base.eltype(L::_TypedLaplacian) = eltype(L.matrix)
+# Interface
+Concrete subtypes of [`SDiagonalizability._TypedLaplacian`](@ref) **must** implement the
+following fields:
+- `matrix::Matrix{Int}`: the Laplacian matrix of the graph.
 
+# Subtypes
+- [`SDiagonalizability._NullGraphLaplacian`](@ref): a Laplacian wrapper for the (unique)
+    graph with no nodes.
+- [`SDiagonalizability._EmptyGraphLaplacian`](@ref): a Laplacian wrapper for any graph with
+    no edges on `n ≥ 1` nodes.
+- [`SDiagonalizability._CompleteGraphLaplacian`](@ref): a Laplacian wrapper for any graph on
+    `n ≥ 2` nodes where every pair of nodes is connected by an edge and all edges possess
+    the same weight.
+- [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref): a Laplacian wrapper for any graph
+    on `n ≥ 3` nodes with no particular strcuture of relevance in the context of
+    investigating `{-1,0,1}`-spectra.
+
+# Notes
+Given that this type and all its subtypes are privately encapsulated within the
+[`SDiagonalizability`](@ref) module, we expect [`SDiagonalizability._TypedLaplacian`](@ref)
+instances to be created exclusively via the
+[`SDiagonalizability._cast_to_typed_laplacian`](@ref) factory function, which copies each
+input matrix to avoid shared mutability and converts it to a `Matrix{Int}` in the process.
+Therefore, it is safe to restrict the type of `matrix` field (in each concrete subtype) to
+`Matrix{Int}` in lieu of the more generic `AbstractMatrix{<:Integer}`. This decision may
+contribute marginal performance benefits via reduced type complexity and is highly unlikely
+to cause any issues (as this type is never to be exported to the public API). It also serves
+as an additional safeguard against directly passing a (wrongly typed) matrix to a subtype's
+constructor rather than calling [`SDiagonalizability._cast_to_typed_laplacian`](@ref).
+
+On a related note, it seems prudent to discuss the intended use case of
+[`SDiagonalizability._TypedLaplacian`](@ref). The interface and its subtypes are meant to
+support [`SDiagonalizability._cast_to_typed_laplacian`](@ref). This factory, in turn,
+determines which algorithm [`laplacian_spectra_01neg`](@ref) is to implement when computing
+data on the Laplacian matrix of a given graph, as different types of graphs exhibit
+different spectral properties which we may exploit to improve performance.
+"""
+abstract type _TypedLaplacian end
+
+"""
+    struct _NullGraphLaplacian
+
+A wrapper for the Laplacian matrix of the (unique) graph with no nodes.
+
+# Fields
+- `matrix::Matrix{Int}`: the Laplacian in question. (Necessarily a `0×0 Matrix{Int}`.)
+
+# Supertype Hierarchy
+_NullGraphLaplacian <: _TypedLaplacian <: Any
+
+# Notes
+See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
+`{-1,0,1}`-spectral properties of this Laplacian type.
+
+See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
+seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+`AbstractMatrix{<:Integer}`.
+"""
 struct _NullGraphLaplacian <: _TypedLaplacian
     matrix::Matrix{Int}
 end
 
+"""
+    struct _EmptyGraphLaplacian
+
+A wrapper for the Laplacian matrix of any graph with no edges on `n ≥ 1` nodes.
+
+# Fields
+- `matrix::Matrix{Int}`: the `n`-by-`n` Laplacian in question. (Necessarily equal to
+    `zeros(Int, n, n)` for some `n ≥ 1`.)
+
+# Supertype Hierarchy
+_EmptyGraphLaplacian <: _TypedLaplacian <: Any
+
+# Notes
+We are confident in the assumption that `n` is at least `1` because the only graph on zero
+nodes is the null graph, which is handled by the
+[`SDiagonalizability._NullGraphLaplacian`](@ref) type.
+
+See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
+`{-1,0,1}`-spectral properties of this Laplacian type.
+
+See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
+seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+`AbstractMatrix{<:Integer}`.
+"""
 struct _EmptyGraphLaplacian <: _TypedLaplacian
     matrix::Matrix{Int}
 end
 
+"""
+    struct _CompleteGraphLaplacian
+
+A wrapper for the Laplacian of any uniformly weighted complete graph on `n ≥ 2` nodes.
+
+# Fields
+- `matrix::Matrix{Int}`: the `n`-by-`n` Laplacian in question. (Necessarily symmetric with
+    zero row sums and all off-diagonal entries equal to `-weight` for some `n ≥ 2`.)
+- `weight::Int`: the weight of each edge in the graph represented by `matrix`. (Necessarily
+    a nonzero integer.)
+
+# Supertype Hierarchy
+_CompleteGraphLaplacian <: _TypedLaplacian <: Any
+
+# Notes
+The only graph on zero nodes is the null graph (handled by the
+[`SDiagonalizability._NullGraphLaplacian`](@ref) type) and the only graph on one node is an
+empty graph (handled by the [`SDiagonalizability._EmptyGraphLaplacian`](@ref) type), so we
+are confident in the assumption that `n ≥ 2` for any
+[`SDiagonalizability._CompleteGraphLaplacian`](@ref) instance.
+
+See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
+`{-1,0,1}`-spectral properties of this Laplacian type.
+
+See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
+seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+`AbstractMatrix{<:Integer}`.
+"""
 struct _CompleteGraphLaplacian <: _TypedLaplacian
     matrix::Matrix{Int}
     weight::Int
 end
 
+"""
+    struct _ArbitraryGraphLaplacian
+
+A wrapper for the Laplacian of any graph on `n ≥ 3` nodes with no particular structure
+of interest.
+
+# Fields
+- `matrix::Matrix{Int}`: the `n`-by-`n` Laplacian in question. (Necessarily symmetric
+    with zero row sums for some `n ≥ 3`.)
+
+# Supertype Hierarchy
+_ArbitraryGraphLaplacian <: _TypedLaplacian <: Any
+
+# Notes
+The only graph on zero nodes is the null graph (handled by the
+[`SDiagonalizability._NullGraphLaplacian`](@ref) type), the only graph on one node is an
+empty graph (handled by the [`SDiagonalizability._EmptyGraphLaplacian`](@ref) type), and the
+only graphs on two nodes are an empty graph and a complete graph (handled by the
+[`SDiagonalizability._CompleteGraphLaplacian`](@ref) type), so we are confident in the
+assumption that `n ≥ 3` for any [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref)
+instance.
+
+See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
+`{-1,0,1}`-spectral properties of this Laplacian type.
+
+See also the documentation for parent type [`SDiagonalizability._TypedLaplacian`](@ref) if
+seeking justification for typing the `matrix` field as `Matrix{Int}` rather than
+`AbstractMatrix{<:Integer}`.
+"""
 struct _ArbitraryGraphLaplacian <: _TypedLaplacian
     matrix::Matrix{Int}
 end
 
+"""
+    _cast_to_typed_laplacian(L)
+
+Classify a Laplacian matrix and wrap it with [`SDiagonalizability._TypedLaplacian`](@ref).
+
+`L` is classified based on any properties which may be exploited in computing data on its
+`{-1,0,1}`-spectrum. It is first verified that `L` is indeed a valid Laplacian matrix.
+
+# Arguments
+- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix to classify.
+
+# Returns
+- `TL::_TypedLaplacian`: the Laplacian wrapped in a concrete
+    [`SDiagonalizability._TypedLaplacian`](@ref) subtype associated with the category of the
+    graph represented by `L`. In the case of complete graphs, `TL` also contains data on the
+    (necessarily uniform) weight of each edge.
+
+# Examples
+Correctly recognizes the Laplacian matrix of the null graph:
+```jldoctest; setup = :(using SDiagonalizability, Graphs)
+julia> G = Graph(0)
+{0, 0} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+0×0 SparseArrays.SparseMatrixCSC{Int64, Int64} with 0 stored entries
+
+julia> TL = SDiagonalizability._cast_to_typed_laplacian(L)
+SDiagonalizability._NullGraphLaplacian(Matrix{Int64}(undef, 0, 0))
+
+julia> isa(TL, SDiagonalizability._NullGraphLaplacian)
+true
+```
+
+Correctly recognizes the Laplacian matrix of the empty graph on `3` nodes:
+```jldoctest; setup = :(using SDiagonalizability, Graphs)
+julia> G = Graph(3)
+{3, 0} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 0 stored entries:
+ ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅
+
+julia> TL = SDiagonalizability._cast_to_typed_laplacian(L)
+SDiagonalizability._EmptyGraphLaplacian([0 0 0; 0 0 0; 0 0 0])
+
+julia> isa(TL, SDiagonalizability._EmptyGraphLaplacian)
+true
+```
+
+Correctly recognizes the Laplacian matrix of the complete graph on `4` nodes:
+```jldoctest; setup = :(using SDiagonalizability, Graphs)
+julia> G = complete_graph(4)
+{4, 6} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+4×4 SparseArrays.SparseMatrixCSC{Int64, Int64} with 16 stored entries:
+  3  -1  -1  -1
+ -1   3  -1  -1
+ -1  -1   3  -1
+ -1  -1  -1   3
+
+julia> TL = SDiagonalizability._cast_to_typed_laplacian(L)
+SDiagonalizability._CompleteGraphLaplacian([3 -1 -1 -1; -1 3 -1 -1; -1 -1 3 -1; -1 -1 -1 3], -1)
+
+julia> isa(TL, SDiagonalizability._CompleteGraphLaplacian)
+true
+```
+
+Correctly recognizes the Laplacian matrix of this random generic graph:
+```jldoctest; setup = :(using SDiagonalizability, Graphs)
+julia> G = erdos_renyi(5, 8; seed=87)
+{5, 8} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+5×5 SparseArrays.SparseMatrixCSC{Int64, Int64} with 21 stored entries:
+  3   ⋅  -1  -1  -1
+  ⋅   2  -1  -1   ⋅
+ -1  -1   4  -1  -1
+ -1  -1  -1   4  -1
+ -1   ⋅  -1  -1   3
+
+julia> TL = SDiagonalizability._cast_to_typed_laplacian(L)
+SDiagonalizability._ArbitraryGraphLaplacian([3 0 … -1 -1; 0 2 … -1 0; … ; -1 -1 … 4 -1; -1 0 … -1 3])
+
+julia> isa(TL, SDiagonalizability._ArbitraryGraphLaplacian)
+true
+```
+# Notes
+Right now, the possible types of Laplacian matrices (or, to be more precise, the graphs they
+represent) are:
+- [`SDiagonalizability._NullGraphLaplacian`](@ref): the (unique) graph with no nodes.
+- [`SDiagonalizability._EmptyGraphLaplacian`](@ref): any graph with no edges on `n ≥ 1`
+    nodes.
+- [`SDiagonalizability._CompleteGraphLaplacian`](@ref): any graph on `n ≥ 2` nodes where
+    every pair of nodes is connected by an edge and all edges possess the same weight.
+- [`SDiagonalizability._ArbitraryGraphLaplacian`](@ref): any graph on `n ≥ 3` nodes with no
+    particular strcuture of relevance in the context of investigating `{-1,0,1}`-spectra.
+"""
 function _cast_to_typed_laplacian(L::AbstractMatrix{<:Integer})
+    #= Verify that `L` is symmetric (thus representing an undirected graph) and has zero row
+    sums (thus being a Laplacian matrix). =#
     _assert_matrix_is_undirected_laplacian(L)
+
     L_copy = Matrix{Int}(L) # Avoid shared mutability and cast to `Matrix{Int}`
     n = size(L_copy, 1)
 
-    if n == 0
+    if n == 0 # The graph has no nodes
         TL = _NullGraphLaplacian(L_copy)
-    elseif iszero(L_copy)
+    elseif iszero(L_copy) # The graph has no edges
         TL = _EmptyGraphLaplacian(L_copy)
-    elseif allequal(L_copy[i, j] for i in 1:n, j in 1:n if i != j)
+        #= We have already verified symmetry, so equality of all strictly upper-triangular
+        elements is a sufficient condition for `L` to represent a complete graph. =#
+    elseif allequal(L_copy[i, j] for i in 1:(n - 1) for j in (i + 1):n)
         weight = L_copy[1, 2]
         TL = _CompleteGraphLaplacian(L_copy, weight)
-    else
+    else # The graph has no particular structure of interest
         TL = _ArbitraryGraphLaplacian(L_copy)
     end
 

--- a/src/factories/orthogonality_properties.jl
+++ b/src/factories/orthogonality_properties.jl
@@ -22,30 +22,28 @@ values of `k`. For each family of values, we apply a separate algorithm to deter
 there exists a permutation of a given collection of vectors that induces `k`-orthogonality.
 
 # Interface
-Concrete subtypes of [`SDiagonalizability._KOrthogonality`](@ref) **must** implement the
-following properties:
+Concrete subtypes of [`_KOrthogonality`](@ref) **must** implement the following properties:
 - `k::Int`: the `k`-orthogonality parameter.
 
 `k` need not necessarily be a field of the subtype (especially in the case of single-value
-types like [`SDiagonalizability._Orthogonality`](@ref) and
-[`SDiagonalizability._QuasiOrthogonality`](@ref), in which case making `k` a field may
-erroneously imply that it is variable), but it must be accessible via `Base.getproperty`.
+types like [`_Orthogonality`](@ref) and [`_QuasiOrthogonality`](@ref), in which case making
+`k` a field may erroneously imply that it is variable), but it must be accessible via
+`Base.getproperty`.
 
 # Subtypes
-- [`SDiagonalizability._Orthogonality`](@ref): `k`-orthogonality for `k = 1`.
-- [`SDiagonalizability._QuasiOrthogonality`](@ref): `k`-orthogonality for `k = 2`.
-- [`SDiagonalizability._WeakOrthogonality`](@ref): `k`-orthogonality for `k > 2`.
+- [`_Orthogonality`](@ref): `k`-orthogonality for `k = 1`.
+- [`_QuasiOrthogonality`](@ref): `k`-orthogonality for `k = 2`.
+- [`_WeakOrthogonality`](@ref): `k`-orthogonality for `k > 2`.
 
 # Notes
 Given the domain restriction of `k` to the positive integers, combined with the relatively
 small nature (`≤ 25`) of bandwidths examined by this package's principal *S*-bandwidth
-minimzation algorithm, it may seem prudent to ask why we do not type the `k` field as
+minimization algorithm, it may seem prudent to ask why we do not type the `k` field as
 `UInt8` instead of `Int`. An equally compelling argument can be made to type it as `Integer`
 for genericity as well. [TODO: Justify]
 
 On that note, the stipulation in the interface contract that `k` be an accessible property
-even for [`SDiagonalizability._Orthogonality`](@ref) and
-[`SDiagonalizability._QuasiOrthogonality`](@ref) [TODO: Elaborate]
+even for [`_Orthogonality`](@ref) and [`_QuasiOrthogonality`](@ref) [TODO: Elaborate]
 
 Another design choice worth scrutinizing is the "`_WeakOrthogonality`" name. "Orthogonality"
 is a term as old as time and "quasi-orthogonality" too has risen to prominence in recent
@@ -56,14 +54,13 @@ attempts to formally introduce as a new definition in the broader literature bey
 hoc* use (and but internally, at that) in this module.
 
 Finally, we note that it may be slightly misleading to state that this type is used to
-inform our choice of algorithm in determining whether a given collection of vectors is
-*`k`-orthogonalizable* (i.e., whether there exists a permutation of said collection that
-induces `k`-orthogonality). Rather, we use it when determining whether a large, linearly
-dependent set of vectors contains an `k`-orthogonal independent spanning subset. This is
-still related to the long-standing matrix bandwidth minimzation problem, but it differs in
-that we can take advantage of dynamic programming techniques when recursively searching for
-such a subset. (See the documentation for
-[`SDiagonalizability._find_k_orthogonal_basis`](@ref) for further details.)
+inform our choice of algorithm in determining whether a collection of vectors is
+*`k`-orthogonalizable* (i.e., whether there exists a `k`-orthogonal permutation of said
+collection). Rather, we use it when determining whether a large, linearly dependent set of
+vectors contains an `k`-orthogonal independent spanning subset. This is still related to the
+long-standing matrix bandwidth minimization problem, but it differs in that we can take
+advantage of dynamic programming techniques when recursively searching for such a subset.
+(See the documentation for [`_find_k_orthogonal_basis`](@ref) for further details.)
 """
 abstract type _KOrthogonality end
 
@@ -84,8 +81,8 @@ _Orthogonality <: _KOrthogonality <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
-`k = 1`, we define the singleton instance [`SDiagonalizability._ORTHOGONALITY`](@ref) to
-always be used when needed in favor of instantiating an identical object every time.
+`k = 1`, we define the singleton instance [`_ORTHOGONALITY`](@ref) to always be used when
+needed in favor of instantiating an identical object every time.
 """
 struct _Orthogonality <: _KOrthogonality end
 
@@ -101,11 +98,11 @@ end
 """
     _ORTHOGONALITY::_Orthogonality
 
-A singleton instance of the [`SDiagonalizability._Orthogonality`](@ref) type.
+A singleton instance of the semantically unique [`_Orthogonality`](@ref) type.
 
-This constant is used to represents the semantically unique property of pairwise
-orthogonality for a collection of vectors and should be always be used in favor of
-instantiating a new object with `_Orthogonality()` every time.
+This constant is used to represent the property of pairwise orthogonality for a collection
+of vectors and should be always be used in favor of instantiating a new object with
+`_Orthogonality()` every time.
 
 [TODO: Justify further]
 """
@@ -129,8 +126,8 @@ _QuasiOrthogonality <: _KOrthogonality <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
-`k = 2`, we define the singleton instance [`SDiagonalizability._QUASI_ORTHOGONALITY`](@ref)
-to always be used when needed in favor of instantiating an identical object every time.
+`k = 2`, we define the singleton instance [`_QUASI_ORTHOGONALITY`](@ref) to always be used
+when needed in favor of instantiating an identical object every time.
 """
 struct _QuasiOrthogonality <: _KOrthogonality end
 
@@ -146,11 +143,11 @@ end
 """
     _QUASI_ORTHOGONALITY::_QuasiOrthogonality
 
-A singleton instance of the [`SDiagonalizability._QuasiOrthogonality`](@ref) type.
+A singleton instance of the semantically unique [`_QuasiOrthogonality`](@ref) type.
 
-This constant is used to represents the semantically unique property of quasi-orthogonality
-for a collection of vectors and should be always be used in favor of instantiating a new
-object with `_QuasiOrthogonality()` every time.
+This constant is used to represents the property of quasi-orthogonality for a collection of
+vectors and should be always be used in favor of instantiating a new object with
+`_QuasiOrthogonality()` every time.
 
 [TODO: Justify further]
 """
@@ -175,15 +172,15 @@ orthogonal). This is equivalent to the vectors' Gram matrix having bandwidth at 
 _WeakOrthogonality <: _KOrthogonality <: Any
 
 # Constructors
-- `_WeakOrthogonality(k::Int)`: constructs a [`SDiagonalizability._WeakOrthogonality`](@ref)
-    object with the given `k`-orthogonality parameter. Throws a `DomainError` if `k <= 2`.
+- `_WeakOrthogonality(k::Int)`: constructs a [`_WeakOrthogonality`](@ref) object with the
+    given `k`-orthogonality parameter. Throws a `DomainError` if `k <= 2`.
 
 # Notes
 The term "weak orthogonality" is not standard terminology in the literature, but it is used
 here to emphasize the weaker nature of this property compared to orthogonality and
 quasi-orthogonality. It is an *ad hoc* term coined for this module and is not intended to
 be formally introduced in the broader literature. See also the documentation for parent type
-[`SDiagonalizability._KOrthogonality`](@ref) for further discussion of this topic.
+[`_KOrthogonality`](@ref) for further discussion of this topic.
 """
 struct _WeakOrthogonality <: _KOrthogonality
     k::Int
@@ -213,8 +210,8 @@ values to which our `k` parameter belongs informs our choice of algorithm.
 - `k::Int`: the `k`-orthogonality parameter to classify. Must be a positive integer.
 
 # Returns
-- `::_KOrthogonality`: An instance of a concrete
-    [`SDiagonalizability._KOrthogonality`](@ref) subtype corresponding to `k`.
+- `::_KOrthogonality`: An instance of a concrete [`_KOrthogonality`](@ref) subtype
+    corresponding to `k`.
 
 # Throws
 - `DomainError`: if `k` is not a positive integer.
@@ -235,8 +232,8 @@ SDiagonalizability._WeakOrthogonality(13)
 ```
 
 # Notes
-See the documentation for [`SDiagonalizability._find_k_orthogonal_basis`](@ref) for further
-details on how this function is used in the context of finding a `k`-orthogonal basis.
+See the documentation for [`_find_k_orthogonal_basis`](@ref) for further details on how this
+function is used in the context of finding a `k`-orthogonal basis.
 """
 function _classify_orthogonality_property(k::Int)
     k < 1 && throw(DomainError(k, "k-orthogonality parameter must be a positive integer"))

--- a/src/factories/orthogonality_properties.jl
+++ b/src/factories/orthogonality_properties.jl
@@ -4,40 +4,250 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Add comments and docstrings to this file
+"""
+    abstract type _KOrthogonality
 
-# TODO: When writing the docstring, make sure to include a `Subtypes` section
+An abstract type representing the property of `k`-orthogonality of a collection of vectors.
+
+Recall that an (ordered) collection of vectors `v₁, v₂, ..., vₙ` is said to be
+*`k`-orthogonal* if we have the inner product `⟨vᵢ, vⱼ⟩ = 0` whenever `|i - j| ≥ k` (i.e.,
+if every pair of vectors at least `k` indices apart is orthogonal). This is equivalent to
+the vectors' Gram matrix having bandwidth at most `k`, where we define the bandwidth of a
+matrix `A` to be the minimum positive integer `k` such that `aᵢⱼ = 0` whenever `|i - j| ≥ k`
+[JP25; p. 313](@cite). (Note that many texts instead define matrix bandwidth using
+zero-based indexing—that is, with the condition `|i - j| > k` [Maf14; p. 186](@cite).)
+
+This type is used as a template for concretely defined properties corresponding to specific
+values of `k`. For each family of values, we apply a separate algorithm to determine whether
+there exists a permutation of a given collection of vectors that induces `k`-orthogonality.
+
+# Interface
+Concrete subtypes of [`SDiagonalizability._KOrthogonality`](@ref) **must** implement the
+following properties:
+- `k::Int`: the `k`-orthogonality parameter.
+
+`k` need not necessarily be a field of the subtype (especially in the case of single-value
+types like [`SDiagonalizability._Orthogonality`](@ref) and
+[`SDiagonalizability._QuasiOrthogonality`](@ref), in which case making `k` a field may
+erroneously imply that it is variable), but it must be accessible via `Base.getproperty`.
+
+# Subtypes
+- [`SDiagonalizability._Orthogonality`](@ref): `k`-orthogonality for `k = 1`.
+- [`SDiagonalizability._QuasiOrthogonality`](@ref): `k`-orthogonality for `k = 2`.
+- [`SDiagonalizability._WeakOrthogonality`](@ref): `k`-orthogonality for `k > 2`.
+
+# Notes
+Given the domain restriction of `k` to the positive integers, combined with the relatively
+small nature (`≤ 25`) of bandwidths examined by this package's principal *S*-bandwidth
+minimzation algorithm, it may seem prudent to ask why we do not type the `k` field as
+`UInt8` instead of `Int`. An equally compelling argument can be made to type it as `Integer`
+for genericity as well. [TODO: Justify]
+
+On that note, the stipulation in the interface contract that `k` be an accessible property
+even for [`SDiagonalizability._Orthogonality`](@ref) and
+[`SDiagonalizability._QuasiOrthogonality`](@ref) [TODO: Elaborate]
+
+Another design choice worth scrutinizing is the "`_WeakOrthogonality`" name. "Orthogonality"
+is a term as old as time and "quasi-orthogonality" too has risen to prominence in recent
+years (e.g., [JP25; p. 313](@cite)), but "weak orthogonality," strictly speaking, is not
+standard terminology. We have taken the liberty of coining it here for `k > 2` to emphasize
+its weaker nature compared to orthogonality and quasi-orthogonality. That said, we make no
+attempts to formally introduce as a new definition in the broader literature beyond its *ad
+hoc* use (and but internally, at that) in this module.
+
+Finally, we note that it may be slightly misleading to state that this type is used to
+inform our choice of algorithm in determining whether a given collection of vectors is
+*`k`-orthogonalizable* (i.e., whether there exists a permutation of said collection that
+induces `k`-orthogonality). Rather, we use it when determining whether a large, linearly
+dependent set of vectors contains an `k`-orthogonal independent spanning subset. This is
+still related to the long-standing matrix bandwidth minimzation problem, but it differs in
+that we can take advantage of dynamic programming techniques when recursively searching for
+such a subset. (See the documentation for
+[`SDiagonalizability._find_k_orthogonal_basis`](@ref) for further details.)
+"""
 abstract type _KOrthogonality end
 
-# TODO: When writing the docstrings, make sure to include a `Supertype Hierarchy` section
+"""
+    struct _Orthogonality
+
+Represents the property of pairwise orthogonality for a collection of vectors.
+
+Recall that a collection of vectors `v₁, v₂, ..., vₙ` is said to be pairwise *orthogonal* if
+we have the inner product `⟨vᵢ, vⱼ⟩ = 0` whenever `|i - j| ≥ 1` (i.e., if every pair of
+vectors is orthogonal). This is equivalent to the vectors' Gram matrix being diagonal.
+
+# Properties
+- `k::Int`: the `k`-orthogonality parameter. (Necessarily `1`.)
+
+# Supertype Hierarchy
+_Orthogonality <: _KOrthogonality <: Any
+
+# Notes
+Since this type is semantically unique inasmuch as it simply encodes the information
+`k = 1`, we define the singleton instance [`SDiagonalizability._ORTHOGONALITY`](@ref) to
+always be used when needed in favor of instantiating an identical object every time.
+"""
 struct _Orthogonality <: _KOrthogonality end
+
+function Base.getproperty(::_Orthogonality, name::Symbol)
+    if name == :k
+        return 1
+    else
+        # This should throw an error, unless we later add fields to this type
+        return getfield(_Orthogonality, name)
+    end
+end
+
+"""
+    _ORTHOGONALITY::_Orthogonality
+
+A singleton instance of the [`SDiagonalizability._Orthogonality`](@ref) type.
+
+This constant is used to represents the semantically unique property of pairwise
+orthogonality for a collection of vectors and should be always be used in favor of
+instantiating a new object with `_Orthogonality()` every time.
+
+[TODO: Justify further]
+"""
+const _ORTHOGONALITY = _Orthogonality()
+
+"""
+    struct _QuasiOrthogonality
+
+Represents the property of quasi-orthogonality for a collection of vectors.
+
+Recall that an (ordered) collection of vectors `v₁, v₂, ..., vₙ` is said to be
+*quasi-orthogonal* if we have the inner product `⟨vᵢ, vⱼ⟩ = 0` whenever `|i - j| ≥ 2` (i.e.,
+if every pair of vectors at least `2` indices apart is orthogonal). This is equivalent to
+the vectors' Gram matrix being tridiagonal [JP25; p. 313](@cite).
+
+# Properties
+- `k::Int`: the `k`-orthogonality parameter. (Necessarily `2`.)
+
+# Supertype Hierarchy
+_QuasiOrthogonality <: _KOrthogonality <: Any
+
+# Notes
+Since this type is semantically unique inasmuch as it simply encodes the information
+`k = 2`, we define the singleton instance [`SDiagonalizability._QUASI_ORTHOGONALITY`](@ref)
+to always be used when needed in favor of instantiating an identical object every time.
+"""
 struct _QuasiOrthogonality <: _KOrthogonality end
+
+function Base.getproperty(::_QuasiOrthogonality, name::Symbol)
+    if name == :k
+        return 2
+    else
+        # This should throw an error, unless we later add fields to this type
+        return getfield(_QuasiOrthogonality, name)
+    end
+end
+
+"""
+    _QUASI_ORTHOGONALITY::_QuasiOrthogonality
+
+A singleton instance of the [`SDiagonalizability._QuasiOrthogonality`](@ref) type.
+
+This constant is used to represents the semantically unique property of quasi-orthogonality
+for a collection of vectors and should be always be used in favor of instantiating a new
+object with `_QuasiOrthogonality()` every time.
+
+[TODO: Justify further]
+"""
+const _QUASI_ORTHOGONALITY = _QuasiOrthogonality()
+
+"""
+    struct _WeakOrthogonality
+
+Represents the property of "weak orthogonality" for a collection of vectors.
+
+In particular, "weak orthogonality" is an *ad hoc* term used to refer to the property of
+`k`-orthogonality for `k > 2`. Recall that an (ordered) collection of vectors
+`v₁, v₂, ..., vₙ` is said to be *`k`-orthogonal* if we have the inner product `⟨vᵢ, vⱼ⟩ = 0`
+whenever `|i - j| ≥ k` (i.e., if every pair of vectors at least `k` indices apart is
+orthogonal). This is equivalent to the vectors' Gram matrix having bandwidth at most `k`.
+
+# Fields
+- `k::Int`: the `k`-orthogonality parameter. (Necessarily a positive integer greater than
+    `2`.)
+
+# Supertype Hierarchy
+_WeakOrthogonality <: _KOrthogonality <: Any
+
+# Constructors
+- `_WeakOrthogonality(k::Int)`: constructs a [`SDiagonalizability._WeakOrthogonality`](@ref)
+    object with the given `k`-orthogonality parameter. Throws a `DomainError` if `k <= 2`.
+
+# Notes
+The term "weak orthogonality" is not standard terminology in the literature, but it is used
+here to emphasize the weaker nature of this property compared to orthogonality and
+quasi-orthogonality. It is an *ad hoc* term coined for this module and is not intended to
+be formally introduced in the broader literature. See also the documentation for parent type
+[`SDiagonalizability._KOrthogonality`](@ref) for further discussion of this topic.
+"""
 struct _WeakOrthogonality <: _KOrthogonality
     k::Int
+
+    function _WeakOrthogonality(k::Int)
+        if k <= 2
+            throw(
+                DomainError(
+                    k, "k-orthogonality parameter must be a positive integer greater than 2"
+                ),
+            )
+        end
+
+        return new(k)
+    end
 end
 
-function Base.getproperty(obj::_Orthogonality, name::Symbol)
-    name == :k && return 1
-    error("type $(typeof(obj)) has no field $name")
-end
+"""
+    _classify_orthogonality_property(k)
 
-function Base.getproperty(obj::_QuasiOrthogonality, name::Symbol)
-    name == :k && return 2
-    error("type $(typeof(obj)) has no field $name")
-end
+Classifies the `k`-orthogonality property based on the given `k` parameter.
 
+When searching for a `k`-orthogonal *S*-basis of a given Laplacian eigenspace, the family of
+values to which our `k` parameter belongs informs our choice of algorithm.
+
+# Arguments
+- `k::Int`: the `k`-orthogonality parameter to classify. Must be a positive integer.
+
+# Returns
+- `::_KOrthogonality`: An instance of a concrete
+    [`SDiagonalizability._KOrthogonality`](@ref) subtype corresponding to `k`.
+
+# Throws
+- `DomainError`: if `k` is not a positive integer.
+
+# Examples
+```jldoctest; setup = :(using SDiagonalizability)
+julia> SDiagonalizability._classify_orthogonality_property(1)
+SDiagonalizability._Orthogonality()
+
+julia> SDiagonalizability._classify_orthogonality_property(2)
+SDiagonalizability._QuasiOrthogonality()
+
+julia> SDiagonalizability._classify_orthogonality_property(3)
+SDiagonalizability._WeakOrthogonality(3)
+
+julia> SDiagonalizability._classify_orthogonality_property(13)
+SDiagonalizability._WeakOrthogonality(13)
+```
+
+# Notes
+See the documentation for [`SDiagonalizability._find_k_orthogonal_basis`](@ref) for further
+details on how this function is used in the context of finding a `k`-orthogonal basis.
+"""
 function _classify_orthogonality_property(k::Int)
     k < 1 && throw(DomainError(k, "k-orthogonality parameter must be a positive integer"))
 
     if k == 1
-        prop = _Orthogonality()
+        prop = _ORTHOGONALITY
     elseif k == 2
-        prop = _QuasiOrthogonality()
+        prop = _QUASI_ORTHOGONALITY
     else
         prop = _WeakOrthogonality(k)
     end
 
     return prop
 end
-
-# TODO: Some impl's?

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -6,6 +6,11 @@
 
 # TODO: Add docstrings to this file, and some comments to the structs and associated methods
 
+"""
+    struct SpectrumIntegralResult
+
+TODO: Write here
+"""
 struct SpectrumIntegralResult
     matrix::Matrix{Int}
     spectrum_integral::Bool
@@ -29,6 +34,11 @@ struct SpectrumIntegralResult
     end
 end
 
+"""
+    struct _Eigenspace01Neg
+
+TODO: Write here
+"""
 struct _Eigenspace01Neg
     dimension::Int
     eigvecs_01neg::AbstractMatrix{Int}
@@ -37,19 +47,24 @@ struct _Eigenspace01Neg
     basis_1neg::Union{Nothing,Matrix{Int}}
 end
 
-struct _LaplacianSpectrum01Neg
+"""
+    struct LaplacianSpectrum01Neg
+
+TODO: Write here
+"""
+struct LaplacianSpectrum01Neg
     laplacian_matrix::Matrix{Int}
     diagonalizable_01neg::Bool
     diagonalizable_1neg::Bool
     eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}
 end
 
-function Base.getproperty(obj::_LaplacianSpectrum01Neg, name::Symbol)
+function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
     if name == :dimension || !(name in fieldnames(_Eigenspace01Neg))
         error("type $(typeof(obj)) has no field $name")
     end
 
-    if name != :eigspaces_01neg && name in fieldnames(_LaplacianSpectrum01Neg)
+    if name != :eigspaces_01neg && name in fieldnames(LaplacianSpectrum01Neg)
         value = getfield(obj, name)
     elseif getfield(obj, :diagonalizable_01neg)
         eigspaces_01neg = getfield(obj, :eigspaces_01neg)
@@ -70,6 +85,12 @@ function Base.getproperty(obj::_LaplacianSpectrum01Neg, name::Symbol)
     return value
 end
 
+#= TODO: (1) Actually implement this sorting in `src/s_bandwidth.jl` once we write it. First
+check if it is sorted, raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not, then
+sort. This will be slower if the input is not sorted but faster if it is (as we expect). =#
+
+#= TODO: (2) Perhaps some of this documentation go in the `SpectrumIntegralResult`
+docstring instead, although I am leaning towards keeping it here. =#
 """
     check_spectrum_integrality(A)
 
@@ -159,26 +180,20 @@ OrderedCollections.OrderedDict{Int64, Int64} with 3 entries:
 # Notes
 If an undirected graph with integer edge weights is `{-1,0,1}`-diagonalizable (or, more
 restrictively, `{-1,1}`-diagonalizable), then its Laplacian matrix has integer eigenvalues
-[JP25; p. 300](@cite). Hence, validating Laplacian integrality serves as a useful screening
+[JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
 step in *SDiagonalizability.jl*'s principal *S*-bandwidth minimzation algorithm.
 
 It is, perhaps, an odd choice to sort the eigenvalue/multiplicity pairs in this file rather
-than in `src/s_bandwidth.jl`—after all, in the context of the overarching *S*-bandwidth
+than in [`s_bandwidth`](@ref)—after all, in the context of the overarching *S*-bandwidth
 algorithm, this ordering is only ever used to determine which eigenspaces are searched for
-*S*-bases first. However, the inclusion of `check_spectrum_integrality` in the public API
-makes the enforcement of a consistent, natural ordering of the `multiplicites` map in each
-(potentially user-facing) `SpectrumIntegralResult` instance worth it nonetheless.
+*S*-bases first. However, the inclusion of [`check_spectrum_integrality`](@ref) in the
+public API motivates a consistent, natural ordering of the `multiplicites` map in each
+(potentially user-facing) [`SpectrumIntegralResult`](@ref) instance.
 
 Of course, we make it a point to still sort `multiplicities` as desired (first by ascending
-multiplicity then by ascending eigenvalue) in `src/s_bandwidth.jl` itself whenever needed by
-another function; this seems more robust than relying on `check_spectrum_integrality` to do
-so or even folding the logic into the `SpectrumIntegralResult` inner constructor.
-
-TODO: Actually implement this sorting in `src/s_bandwidth.jl` once we write it. Maybe first
-check if it is sorted, raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not, then
-sort? This will be slower if the input is not sorted but faster if it is (as we expect).
-
-TODO: Should some of this explanation go in the `SpectrumIntegralResult` docstring instead?
+multiplicity then by ascending eigenvalue) in `s_bandwidth` itself; this seems more robust
+than relying on [`check_spectrum_integrality`](@ref) to do so or even folding the logic into
+the [`SpectrumIntegralResult`](@ref) inner constructor.
 """
 function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
     A_copy = Matrix{Int}(A) # Avoid shared mutability and cast to `Matrix{Int}`
@@ -237,6 +252,11 @@ julia> SDiagonalizability._extract_independent_cols(A)
 ```
 
 # Notes
+The somewhat rare (although certainly far from unorthodox) choice of QR decomposition for
+our purposes merits discussion. [TODO: Write here]
+
+TODO: Also discuss why we can't just transpose first (gets us independent rows)
+
 TODO: Discuss unusual use of `_rank_rtol`
 """
 function _extract_independent_cols(A::AbstractMatrix{<:Integer})
@@ -248,7 +268,7 @@ function _extract_independent_cols(A::AbstractMatrix{<:Integer})
     pivots = F.p # The first `rank(A)` pivots correspond to independent columns of `A`
     ortho_coefs = diag(F.R) # Scaling factors of the columns of the `Q` matrix
 
-    tol = _rank_rtol(A_float) * maximum(abs, ortho_coefs)
+    tol = _rank_rtol(A_float) * maximum(abs, ortho_coefs) # TODO: Add inline comment
     r = count(x -> abs(x) > tol, ortho_coefs) # The rank of `A` within floating-point error
 
     return A[:, pivots[1:r]] # An independent spanning subset of the columns of `A`
@@ -296,31 +316,30 @@ function _find_indices_1neg(eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int
 end
 
 """
-    _laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
+    laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
+
+Compute data on the {-1,0,1}-spectrum of some Laplacian matrix `L`.
 
 TODO: Write here
 
 # Arguments
-- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix on whose {-1,0,1}-spectrum we are to
-    compute data.
+- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix on whose `{-1,0,1}`-spectrum we are
+    to compute data.
 
 # Returns
-- `::_LaplacianSpectrum01Neg`: a struct containing the following fields:
+- `::LaplacianSpectrum01Neg`: a struct containing the following fields:
     - `laplacian_matrix::Matrix{Int}`: a (casted) copy of `L`, avoiding shared mutability.
     - `diagonalizable_01neg::Bool`: whether the Laplacian is {-1,0,1}-diagonalizable.
     - `diagonalizable_1neg::Bool`: whether the Laplacian is {-1,1}-diagonalizable.
-    - `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: a map from
-        eigenvalues to eigenspaces, sorted first by ascending multiplicity then by ascending
-        eigenvalue. (This field is `nothing` if the Laplacian is not
-        {-1,0,1}-diagonalizable.)
+    - `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: TODO: Write here
 
 # Examples
 TODO: Write here
 
 # Notes
-TODO: Write here
+TODO: Include notes on the relevant properties of each type of Laplacian matrix
 """
-function _laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
+function laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
     TL = _cast_to_typed_laplacian(L)
     return _typed_laplacian_spectra_01neg(TL)
 end
@@ -341,7 +360,7 @@ TODO: Write here
 """
 function _typed_laplacian_spectra_01neg(TL::_NullGraphLaplacian)
     eigspaces_01neg = OrderedDict{Int,_Eigenspace01Neg}()
-    return _LaplacianSpectrum01Neg(TL.matrix, true, true, eigspaces_01neg)
+    return LaplacianSpectrum01Neg(TL.matrix, true, true, eigspaces_01neg)
 end
 
 """
@@ -377,7 +396,7 @@ function _typed_laplacian_spectra_01neg(TL::_EmptyGraphLaplacian)
             kernel_basis_1neg,
         ),
     )
-    return _LaplacianSpectrum01Neg(L, true, diagonalizable_1neg, eigspaces_01neg)
+    return LaplacianSpectrum01Neg(L, true, diagonalizable_1neg, eigspaces_01neg)
 end
 
 """
@@ -444,7 +463,7 @@ function _typed_laplacian_spectra_01neg(TL::_CompleteGraphLaplacian)
         eigspaces_01neg[eigval_nonzero] = nonkernel_01neg
     end
 
-    return _LaplacianSpectrum01Neg(L, true, diagonalizable_1neg, eigspaces_01neg)
+    return LaplacianSpectrum01Neg(L, true, diagonalizable_1neg, eigspaces_01neg)
 end
 
 """
@@ -458,7 +477,7 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
 
     if !res.spectrum_integral
         # For integer edge weights, {-1,0,1}-diagonalizability implies Laplacian integrality
-        return _LaplacianSpectrum01Neg(L, false, false, nothing)
+        return LaplacianSpectrum01Neg(L, false, false, nothing)
     end
 
     n = size(L, 1)
@@ -534,7 +553,7 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
         )
     end
 
-    return _LaplacianSpectrum01Neg(
+    return LaplacianSpectrum01Neg(
         L, res.spectrum_integral, diagonalizable_1neg, eigspaces_01neg
     )
 end

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -174,6 +174,10 @@ multiplicity then by ascending eigenvalue) in `src/s_bandwidth.jl` itself whenev
 another function; this seems more robust than relying on `check_spectrum_integrality` to do
 so or even folding the logic into the `SpectrumIntegralResult` inner constructor.
 
+TODO: Actually implement this sorting in `src/s_bandwidth.jl` once we write it. Maybe first
+check if it is sorted, raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not, then
+sort? This will be slower if the input is not sorted but faster if it is (as we expect).
+
 TODO: Should some of this explanation go in the `SpectrumIntegralResult` docstring instead?
 """
 function check_spectrum_integrality(A::AbstractMatrix{<:Integer})

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -166,8 +166,8 @@ It is, perhaps, an odd choice to sort the eigenvalue/multiplicity pairs in this 
 than in `src/s_bandwidth.jl`—after all, in the context of the overarching *S*-bandwidth
 algorithm, this ordering is only ever used to determine which eigenspaces are searched for
 *S*-bases first. However, the inclusion of `check_spectrum_integrality` in the public API
-motivates the enforcement of a consistent, natural ordering of the `multiplicites` map in
-each (potentially user-facing) `SpectrumIntegralResult` instance.
+makes the enforcement of a consistent, natural ordering of the `multiplicites` map in each
+(potentially user-facing) `SpectrumIntegralResult` instance worth it nonetheless.
 
 Of course, we make it a point to still sort `multiplicities` as desired (first by ascending
 multiplicity then by ascending eigenvalue) in `src/s_bandwidth.jl` itself whenever needed by

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -181,7 +181,7 @@ OrderedCollections.OrderedDict{Int64, Int64} with 3 entries:
 If an undirected graph with integer edge weights is `{-1,0,1}`-diagonalizable (or, more
 restrictively, `{-1,1}`-diagonalizable), then its Laplacian matrix has integer eigenvalues
 [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
-step in *SDiagonalizability.jl*'s principal *S*-bandwidth minimzation algorithm.
+step in this package's principal *S*-bandwidth minimization algorithm.
 
 It is, perhaps, an odd choice to sort the eigenvalue/multiplicity pairs in this file rather
 than in [`s_bandwidth`](@ref)—after all, in the context of the overarching *S*-bandwidth

--- a/src/s_bandwidth.jl
+++ b/src/s_bandwidth.jl
@@ -5,3 +5,10 @@
 # distributed except according to those terms.
 
 # TODO: Implement
+
+"""
+    s_bandwidth()
+
+TODO: Write here. Just a placeholder for `Documenter.jl` as of right now.
+"""
+function s_bandwidth() end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,8 +4,8 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Extend functionality to multi-argument functions. Talk about "dispatch to [type] for
-# [parameter]" rather than the current error message.
+#= TODO: Extend functionality to multi-argument functions. Talk about "dispatch to [type] for
+# [parameter]" rather than the current error message. =#
 struct NotImplementedError <: Exception
     f::Function
     concretetype::Type
@@ -133,8 +133,8 @@ column-major storage model.
 
 At first blush, it may seem as though the choice of `DomainError` over something like
 `ArgumentError` (or even simply the return of a boolean) constitutes poor design. However,
-this is informed by the *ad hoc* use of `assert_matrix_is_undirected_laplacian` to validate
-inputs for other functions requiring Laplacian matrices. This function is never meant to be
+this is informed by the simple *ad hoc* use of this function to validate inputs for other
+functions requiring Laplacian matrices. Certainly, this function is never meant to be
 publicly exposed on its own.
 """
 function _assert_matrix_is_undirected_laplacian(L::AbstractMatrix{<:Integer})
@@ -169,7 +169,7 @@ count(Δ .> maximum(Δ) * _rank_rtol(A))`.
 
 Since the machine epsilon is only defined for floating-point types, we call `eps()`
 (defaulting to `Float64`) instead of `eps(eltype(A))` when computing the tolerance. If the
-elements of `A` are floats, on the other hand, then `_rank_rtol` dispatches to a separate
+elements of `A` are floats, on the other hand, then this function dispatches to a separate
 method that uses the element type's machine epsilon.
 
 # Arguments
@@ -191,8 +191,8 @@ the need for this higher tolerance.)
 In the case of using SVD to compute matrix rank, the decision to default to the `Float64`
 machine epsilon is motivated by how `LinearAlgebra.rank` handles non-floating-point
 matrices, as LAPACK automatically converts to `Float64` under the hood. In the case of QRD,
-our *ad hoc* use of this function in `SDiagonalizability._extract_independent_cols` takes in
-floating-point matrices anyway, so this particular method is no longer relevant.
+our *ad hoc* use of this function in [`SDiagonalizability._extract_independent_cols`](@ref)
+takes in floating-point matrices anyway, so this particular method is no longer relevant.
 """
 function _rank_rtol(A::AbstractMatrix{<:Real})
     return sqrt(maximum(size(A)) * eps())

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -191,8 +191,8 @@ the need for this higher tolerance.)
 In the case of using SVD to compute matrix rank, the decision to default to the `Float64`
 machine epsilon is motivated by how `LinearAlgebra.rank` handles non-floating-point
 matrices, as LAPACK automatically converts to `Float64` under the hood. In the case of QRD,
-our *ad hoc* use of this function in [`SDiagonalizability._extract_independent_cols`](@ref)
-takes in floating-point matrices anyway, so this particular method is no longer relevant.
+our *ad hoc* use of this function in [`_extract_independent_cols`](@ref) takes in
+floating-point matrices anyway, so this particular method is no longer relevant.
 """
 function _rank_rtol(A::AbstractMatrix{<:Real})
     return sqrt(maximum(size(A)) * eps())


### PR DESCRIPTION
We have now covered every binding (both public and private) in the codebase with a docstring, having finished perhaps 50% of these docstrings. Additionally, the `Documenter.jl` website is fleshed out with a homepage, public API documentation, and private API documentation.