### PR TITLE
Update table rendering in docs homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
       </table>
     </td>
     <td>
-      <img src="https://github.com/GraphQuantum/SDiagonalizability.jl/raw/main/docs/src/assets/logo.jpg" alt="GraphQuantum logo by Madiha Waqar" width="170"><br>
+      <img src="https://github.com/GraphQuantum/SDiagonalizability.jl/raw/main/docs/src/assets/logo.jpg" alt="GraphQuantum logo by Madiha Waqar" height="170"><br>
       <sup><sub><em>GraphQuantum</em> logo by <a href="https://github.com/madihaahmed1">Madiha Waqar</a></sub></sup>
     </td>
   </tr>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ makedocs(;
     format=Documenter.HTML(;
         canonical="https://GraphQuantum.github.io/SDiagonalizability.jl",
         edit_link="main",
-        assets=String[],
+        assets=["assets/styles.css"],
     ),
     plugins=[bib],
     pages=[

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -1,0 +1,69 @@
+html {
+  --table-border-color: white;
+  --table-row-shade: rgba(255, 255, 255, 0.1);
+}
+
+html.theme--documenter-light,
+html.theme--catppuccin-latte {
+  --table-border-color: black;
+  --table-row-shade: rgba(0, 0, 0, 0.1);
+}
+
+table {
+  width: auto;
+  border-collapse: collapse;
+}
+
+table tr:nth-child(even) {
+  background-color: var(--table-row-shade);
+}
+
+tr, th, td {
+  border: 1px solid var(--table-border-color);
+}
+
+table > tbody > tr > th:first-child,
+table > tbody > tr > td:first-child {
+  border-right: 1px solid var(--table-border-color) !important;
+}
+
+table > tbody > tr > th:last-child,
+table > tbody > tr > td:last-child {
+  border-left: 1px solid var(--table-border-color) !important;
+}
+
+table td figure {
+  height: 200px;
+  margin: 0 !important;
+}
+
+table td figure img {
+  max-height: 190px;
+  width: auto;
+  height: auto;
+}
+
+table td figure figcaption {
+  font-size: 0.75em;
+}
+
+@media (max-width: 800px) {
+  table td, table th {
+    font-size: 0.75em;
+  }
+
+  table img:not(figure img) {
+    transform: scale(0.75);
+  }
+
+  table td figure {
+    height: 150px;
+    margin: 0 !important;
+  }
+
+  table td figure img {
+    max-height: 140px;
+    width: auto;
+    height: auto;
+  }
+}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,7 @@
 CurrentModule = SDiagonalizability
 ```
 
+```@raw html
 <table>
   <tr>
     <td>
@@ -43,11 +44,16 @@ CurrentModule = SDiagonalizability
       </table>
     </td>
     <td>
-      <img src="https://github.com/GraphQuantum/SDiagonalizability.jl/raw/main/docs/src/assets/logo.jpg" alt="GraphQuantum logo by Madiha Waqar" width="170"><br>
-      <sup><sub><em>GraphQuantum</em> logo by <a href="https://github.com/madihaahmed1">Madiha Waqar</a></sub></sup>
+      <figure>
+        <img src="https://github.com/GraphQuantum/SDiagonalizability.jl/raw/main/docs/src/assets/logo.jpg" alt="GraphQuantum logo by Madiha Waqar">
+        <figcaption>
+          <em>GraphQuantum</em> logo by <a href="https://github.com/madihaahmed1">Madiha Waqar</a>
+        </figcaption>
+      </figure>
     </td>
   </tr>
 </table>
+```
 
 # SDiagonalizability.jl
 


### PR DESCRIPTION
Got the summary table to render properly in the Documenter homepage, and applied some CSS styling. Also, edited the `img` styling for the summary table in the `README.md`.