### PR TITLE
Flesh out documentation + inline comments

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,2 @@
 style = "blue"
+always_use_return = true

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 ## Installation
 
-Installation is straightforward using the Julia package manager. First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
+The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
 
 ```julia-repl
 pkg> add https://github.com/GraphQuantum/SDiagonalizability.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,7 +63,7 @@ CurrentModule = SDiagonalizability
 
 ## Installation
 
-Installation is straightforward using the Julia package manager. First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
+The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
 
 ```julia-repl
 pkg> add https://github.com/GraphQuantum/SDiagonalizability.jl

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,3 +1,25 @@
+@article{BG65,
+  author = "Businger, Peter and Golub, Gene H.",
+  title = "Linear Least Squares Solutions by Householder Transformations",
+  journal = "*Numerische Mathematik*",
+  year = 1965,
+  volume = "7",
+  number = "3",
+  pages = "269--276",
+  url = "https://doi.org/10.1007/BF01436084",
+}
+
+@article{CD05,
+  author = "Chen, Zizhong and Dongarra, Jackie",
+  title = "Condition Numbers of Gaussian Random Matrices",
+  journal = "*SIAM Journal on Matrix Analysis and Applications*",
+  year = 2005,
+  volume = "27",
+  number = "3",
+  pages = "603--620",
+  url = "https://doi.org/10.1137/040616413",
+}
+
 @misc{Deu25,
   title = "Number of humps in all Motzkin paths of length n",
   author = "Deutsch, Emeric",
@@ -44,13 +66,33 @@
   url = "https://doi.org/10.2478/awutm-2014-0019",
 }
 
-@misc{numpy25,
-  title = "{numpy.linalg.matrix_rank}",
+@misc{MAT25,
+  title = "rank",
+  author = "{MATLAB Developers}",
+  howpublished = "MATLAB reference documentation – R2025a",
+  year = 2025,
+  url = "https://www.mathworks.com/help/matlab/ref/rank.html",
+  note = "Accessed: 2025-05-29",
+}
+
+@misc{Num25,
+  title = "numpy.linalg.matrix_rank",
   author = "{NumPy Developers}",
-  howpublished = "NumPy reference documentation (stable)",
+  howpublished = "NumPy reference documentation – v2.2",
   year = 2025,
   url = "https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_rank.html",
   note = "Accessed: 2025-05-22",
+}
+
+@book{PTVF07,
+  author = "Press, William H. and Teukolsky, Saul A. and Vetterling, William T. and Flannery, Brian P.",
+  title = "Numerical Recipes: The Art of Scientific Computing",
+  publisher = "Cambridge University Press",
+  address = "Cambridge, UK",
+  year = 2007,
+  edition = "3rd",
+  url = "https://dl.acm.org/doi/10.5555/1403886",
+  note = "ISBN: 978-0-521-88068-8",
 }
 
 @misc{Slo25,

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -34,8 +34,6 @@ using MolecularGraph: subgraph_monomorphisms
 # TODO: Create and include `precompile_workload.jl`
 using PrecompileTools: @setup_workload, @compile_workload
 
-# TODO: Check if we really need the module preface for cross-referencing private functions
-
 include("utils.jl")
 include("factories/laplacian_types.jl")
 include("factories/orthogonality_properties.jl")
@@ -46,8 +44,8 @@ include("basis_search.jl")
 include("s_bandwidth.jl")
 
 # Exports from `laplacian_spectra.jl`
-export LaplacianSpectrum01Neg, laplacian_spectra_01neg
 export SpectrumIntegralResult, check_spectrum_integrality
+export LaplacianSpectrum01Neg, laplacian_spectra_01neg
 
 # Exports from `s_bandwidth.jl`
 export s_bandwidth

--- a/src/basis_search.jl
+++ b/src/basis_search.jl
@@ -4,8 +4,6 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Add comments and docstrings to this file
-
 """
     mutable struct _QOBasisSearchNodeData
 
@@ -40,7 +38,7 @@ end
 """
     _find_basis_with_property(column_space, column_rank, prop:::_Orthogonality)
 
-TODO: Write here
+TODO: Write here, and add comments
 """
 function _find_basis_with_property(
     column_space::AbstractMatrix{Int}, column_rank::Int, prop::_Orthogonality
@@ -60,7 +58,7 @@ end
 """
     _find_basis_with_property(column_space, column_rank, prop::_QuasiOrthogonality)
 
-TODO: Write here
+TODO: Write here, and add comments
 """
 function _find_basis_with_property(
     column_space::AbstractMatrix{Int}, column_rank::Int, prop::_QuasiOrthogonality
@@ -122,7 +120,8 @@ function _find_basis_with_property(
         ortho_graph_compl_adjacency[diagind(ortho_graph_compl_adjacency)] .= false
 
         #= Before running a subgraph monomorphism search, we can filter out (partial) bases
-        by [TODO: Write here] =#
+        that lack a sufficient number of orthogonality relations to be `k`-orthogonal,
+        regardless of the column ordering. =#
         if all(sum(ortho_graph_compl_adjacency; dims=1) .<= 2k - 2)
             H = Graph(column_rank) # Initialize the empty graph on `column_rank` vertices
 
@@ -200,9 +199,10 @@ function _find_basis_indices(
     depth = length(curr_indices)
     num_columns = size(column_space, 2)
     partial_basis = view(column_space, :, curr_indices)
+    # Use a more robust tolerance (NumPy's and MATLAB's default) than Julia's default
     rtol = _rank_rtol(partial_basis)
 
-    rank(partial_basis, rtol) < depth && return nothing
+    rank(partial_basis; rtol=rtol) < depth && return nothing
 
     parent_partial_basis = view(partial_basis, :, 1:(depth - 1))
     curr_column = view(partial_basis, :, depth)
@@ -295,9 +295,10 @@ function _find_basis_indices(
     depth = length(curr_indices)
     num_columns = size(column_space, 2)
     partial_basis = view(column_space, :, curr_indices)
+    # Use a more robust tolerance (NumPy's and MATLAB's default) than Julia's default
     rtol = _rank_rtol(partial_basis)
 
-    rank(partial_basis, rtol) < depth && return nothing
+    rank(partial_basis; rtol=rtol) < depth && return nothing
 
     parent_partial_basis = view(partial_basis, :, 1:(depth - 1))
     curr_column = view(partial_basis, :, depth)

--- a/src/basis_search.jl
+++ b/src/basis_search.jl
@@ -17,10 +17,31 @@ end
 """
     _find_k_orthogonal_basis(column_space, column_rank, k)
 
-TODO: Write here
+Find a `k`-orthogonal spanning subset of the column set of a matrix.
+
+This function does not allow for any `k`-orthogonal basis of `column_space` (in which case
+it would be trivial to construct a *pairwise* orthogonal basis via a QR decomposition).
+Instead, it restricts its search to spanning subsets comprised exclusively of columns
+already in `column_space`, returning `nothing` if no such basis exists.
+
+# Arguments
+- `column_space::T<:AbstractMatrix{Int}`: the matrix whose column space is search for a
+    `k`-orthogonal basis.
+- `column_rank::Int`: the rank of the column space of `column_space`, pre-computed for
+    efficiency.
+- `k::Integer`: the minimum `k`-orthogonality parameter of the desired basis. (Must be a
+    positive integer.)
+
+# Returns
+- `::Union{Nothing,T}`: a `k`-orthogonal spanning subset of the columns of `column_space`,
+    with the same type as `column_space`. If no such basis exists, this is simply `nothing`.
+
+# Notes
+TODO: Write here. In particular, comment on the "basis" naming and perhaps `k`. Also,
+comment on typing decisions. (Should `k` just be `Int`?)
 """
 function _find_k_orthogonal_basis(
-    column_space::AbstractMatrix{Int}, column_rank::Int, k::Int
+    column_space::AbstractMatrix{Int}, column_rank::Int, k::Integer
 )
     prop = _classify_orthogonality_property(k)
     return _find_basis_with_property(column_space, column_rank, prop)

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -57,7 +57,7 @@ function _pot_kernel_eigvecs_01neg(n::Integer)
                 leading = Vector{Int}(undef, k)
                 leading[1:(k - 1)] .= 0
                 leading[k] = 1 # Normalize the leading entry to 1
-                leading
+                return leading
             end,
             body,
         ) # Append the permuted entries to the leading [0, ..., 0, 1] vector
@@ -139,7 +139,7 @@ function _pot_nonkernel_eigvecs_01neg(n::Integer)
                 leading = Vector{Int}(undef, k)
                 leading[1:(k - 1)] .= 0
                 leading[k] = 1 # Normalize the leading entry to 1
-                leading
+                return leading
             end,
             body,
         ) # Append the permuted entries to the leading [0, ..., 0, 1] vector
@@ -153,7 +153,7 @@ function _pot_nonkernel_eigvecs_01neg(n::Integer)
                 entries[1:j] .= -1
                 entries[(j + 1):(r - j + 1)] .= 0
                 entries[(r - j + 2):r] .= 1
-                entries
+                return entries
             end,
             r,
         )

--- a/src/factories/laplacian_types.jl
+++ b/src/factories/laplacian_types.jl
@@ -53,7 +53,7 @@ A wrapper for the Laplacian matrix of the (unique) graph with no nodes.
 - `matrix::Matrix{Int}`: the Laplacian in question. (Necessarily a `0×0 Matrix{Int}`.)
 
 # Supertype Hierarchy
-_NullGraphLaplacian <: _TypedLaplacian <: Any
+[`_NullGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
@@ -77,7 +77,7 @@ A wrapper for the Laplacian matrix of any graph with no edges on `n ≥ 1` nodes
     `zeros(Int, n, n)` for some `n ≥ 1`.)
 
 # Supertype Hierarchy
-_EmptyGraphLaplacian <: _TypedLaplacian <: Any
+[`_EmptyGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 We are confident in the assumption that `n` is at least `1` because the only graph on zero
@@ -106,7 +106,7 @@ A wrapper for the Laplacian of any uniformly weighted complete graph on `n ≥ 2
     a nonzero integer.)
 
 # Supertype Hierarchy
-_CompleteGraphLaplacian <: _TypedLaplacian <: Any
+[`_CompleteGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
@@ -137,7 +137,7 @@ of interest.
     with zero row sums for some `n ≥ 3`.)
 
 # Supertype Hierarchy
-_ArbitraryGraphLaplacian <: _TypedLaplacian <: Any
+[`_ArbitraryGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
@@ -271,8 +271,10 @@ function _cast_to_typed_laplacian(L::AbstractMatrix{<:Integer})
         TL = _NullGraphLaplacian(L_copy)
     elseif iszero(L_copy) # The graph has no edges
         TL = _EmptyGraphLaplacian(L_copy)
-        #= We have already verified symmetry, so equality of all strictly upper-triangular
-        elements is a sufficient condition for `L` to represent a complete graph. =#
+    #! format: off
+    #= We have already verified symmetry, so equality of all strictly upper-triangular
+    elements is a sufficient condition for `L` to represent a complete graph. =#
+    #! format: on
     elseif allequal(L_copy[i, j] for i in 1:(n - 1) for j in (i + 1):n)
         weight = L_copy[1, 2]
         TL = _CompleteGraphLaplacian(L_copy, weight)

--- a/src/factories/laplacian_types.jl
+++ b/src/factories/laplacian_types.jl
@@ -10,7 +10,7 @@
 An abstract type representing a classified Laplacian matrix of an undirected graph.
 
 # Interface
-Concrete subtypes of [_TypedLaplacian`](@ref) **must** implement the following fields:
+Concrete subtypes of `_TypedLaplacian` **must** implement the following fields:
 - `matrix::Matrix{Int}`: the Laplacian matrix of the graph.
 
 # Subtypes
@@ -25,7 +25,7 @@ Concrete subtypes of [_TypedLaplacian`](@ref) **must** implement the following f
 
 # Notes
 Given that this type and all its subtypes are privately encapsulated, we expect
-[`_TypedLaplacian`](@ref) instances to be created exclusively via the
+`_TypedLaplacian` instances to be created exclusively via the
 [`_cast_to_typed_laplacian`](@ref) factory function, which copies each input matrix to avoid
 shared mutability and converts it to a `Matrix{Int}` in the process. Therefore, it is safe
 to restrict the type of `matrix` field (in each concrete subtype) to `Matrix{Int}` in lieu
@@ -35,12 +35,11 @@ performance benefits via reduced type complexity and is highly unlikely to cause
 safeguard against directly passing a (wrongly typed) matrix to a subtype's constructor
 rather than calling [`_cast_to_typed_laplacian`](@ref).
 
-On a related note, it seems prudent to discuss the intended use case of
-[`_TypedLaplacian`](@ref). The interface and its subtypes are meant to support
-[`_cast_to_typed_laplacian`](@ref). This factory, in turn, determines which algorithm
-[`laplacian_spectra_01neg`](@ref) is to implement when computing data on the Laplacian
-matrix of a given graph, as different types of graphs exhibit different spectral properties
-which we may exploit to improve performance.
+On a related note, it seems prudent to discuss the intended use case of `_TypedLaplacian`.
+The interface and its subtypes are meant to support [`_cast_to_typed_laplacian`](@ref). This
+factory, in turn, determines which algorithm [`laplacian_spectra_01neg`](@ref) is to
+implement when computing data on the Laplacian matrix of a given graph, as different types
+of graphs exhibit different spectral properties which we may exploit to improve performance.
 """
 abstract type _TypedLaplacian end
 
@@ -53,11 +52,11 @@ A wrapper for the Laplacian matrix of the (unique) graph with no nodes.
 - `matrix::Matrix{Int}`: the Laplacian in question. (Necessarily a `0×0 Matrix{Int}`.)
 
 # Supertype Hierarchy
-[`_NullGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
+`_NullGraphLaplacian` <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
-See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
-`{-1,0,1}`-spectral properties of this Laplacian type.
+See the [`_typed_laplacian_spectra_01neg(::_NullGraphLaplacian)`](@ref) documentation for
+more details on the `{-1,0,1}`-spectral properties of this Laplacian type.
 
 See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
 justification for typing the `matrix` field as `Matrix{Int}` rather than
@@ -77,14 +76,14 @@ A wrapper for the Laplacian matrix of any graph with no edges on `n ≥ 1` nodes
     `zeros(Int, n, n)` for some `n ≥ 1`.)
 
 # Supertype Hierarchy
-[`_EmptyGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
+`_EmptyGraphLaplacian` <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 We are confident in the assumption that `n` is at least `1` because the only graph on zero
 nodes is the null graph, which is handled by the [`_NullGraphLaplacian`](@ref) type.
 
-See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
-`{-1,0,1}`-spectral properties of this Laplacian type.
+See the [`_typed_laplacian_spectra_01neg::_EmptyGraphLaplacian`](@ref) documentation for
+more details on the `{-1,0,1}`-spectral properties of this Laplacian type.
 
 See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
 justification for typing the `matrix` field as `Matrix{Int}` rather than
@@ -106,16 +105,16 @@ A wrapper for the Laplacian of any uniformly weighted complete graph on `n ≥ 2
     a nonzero integer.)
 
 # Supertype Hierarchy
-[`_CompleteGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
+`_CompleteGraphLaplacian` <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
 type) and the only graph on one node is an empty graph (handled by the
 [`_EmptyGraphLaplacian`](@ref) type), so we are confident in the assumption that `n ≥ 2` for
-any [`_CompleteGraphLaplacian`](@ref) instance.
+any `_CompleteGraphLaplacian` instance.
 
-See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
-`{-1,0,1}`-spectral properties of this Laplacian type.
+See the [`_typed_laplacian_spectra_01neg::_CompleteGraphLaplacian`](@ref) documentation for
+more details on the `{-1,0,1}`-spectral properties of this Laplacian type.
 
 See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
 justification for typing the `matrix` field as `Matrix{Int}` rather than
@@ -137,18 +136,17 @@ of interest.
     with zero row sums for some `n ≥ 3`.)
 
 # Supertype Hierarchy
-[`_ArbitraryGraphLaplacian`](@ref) <: [`_TypedLaplacian`](@ref) <: Any
+`_ArbitraryGraphLaplacian` <: [`_TypedLaplacian`](@ref) <: Any
 
 # Notes
 The only graph on zero nodes is the null graph (handled by the [`_NullGraphLaplacian`](@ref)
 type), the only graph on one node is an empty graph (handled by the
 [`_EmptyGraphLaplacian`](@ref) type), and the only graphs on two nodes are an empty graph
 and a complete graph (handled by the [`_CompleteGraphLaplacian`](@ref) type), so we are
-confident in the assumption that `n ≥ 3` for any [`_ArbitraryGraphLaplacian`](@ref)
-instance.
+confident in the assumption that `n ≥ 3` for any `_ArbitraryGraphLaplacian` instance.
 
-See the documentation for [`laplacian_spectra_01neg`](@ref) for further details on the
-`{-1,0,1}`-spectral properties of this Laplacian type.
+See the [`_typed_laplacian_spectra_01neg::_ArbitraryGraphLaplacian`](@ref) documentation for
+more details on the `{-1,0,1}`-spectral properties of this Laplacian type.
 
 See also the documentation for parent type [`_TypedLaplacian`](@ref) if seeking
 justification for typing the `matrix` field as `Matrix{Int}` rather than

--- a/src/factories/orthogonality_properties.jl
+++ b/src/factories/orthogonality_properties.jl
@@ -40,10 +40,19 @@ Given the domain restriction of `k` to the positive integers, combined with the 
 small nature (`≤ 25`) of bandwidths examined by this package's principal *S*-bandwidth
 minimization algorithm, it may seem prudent to ask why we do not type the `k` field as
 `UInt8` instead of `Int`. An equally compelling argument can be made to type it as `Integer`
-for genericity as well. [TODO: Justify]
+for genericity as well. However, many methods (both within this module and externally) often
+expect `Int`-typed parameters, so we settle on `Int` as our field type. However, in any
+constructors/factories of [`_KOrthogonality`](@ref) subtypes, we allow the `k`-orthogonality
+input parameter to be any generic `Integer`, simply casting it to an `Int` later on.
 
 On that note, the stipulation in the interface contract that `k` be an accessible property
-even for [`_Orthogonality`](@ref) and [`_QuasiOrthogonality`](@ref) [TODO: Elaborate]
+even for semantically unique types like [`_Orthogonality`](@ref) and
+[`_QuasiOrthogonality`](@ref) may seem somewhat odd, as it will never accessed in practice
+by [`_find_k_orthogonal_basis`](@ref). (Rather, the type itself—which already implicitly
+encodes the value of `k`—directly informs the choice of algorithm in said function.)
+However, we require it nonetheless for the sake of consistency future extensibility, just in
+case the API is later modified to require more generic handling of [`_KOrthogonality`](@ref)
+instances whose specific subtypes are not known based on their `k`-orthogonality parameter.
 
 Another design choice worth scrutinizing is the "`_WeakOrthogonality`" name. "Orthogonality"
 is a term as old as time and "quasi-orthogonality" too has risen to prominence in recent
@@ -67,7 +76,7 @@ abstract type _KOrthogonality end
 """
     struct _Orthogonality
 
-Represents the property of pairwise orthogonality for a collection of vectors.
+The property of pairwise orthogonality for a collection of vectors.
 
 Recall that a collection of vectors `v₁, v₂, ..., vₙ` is said to be pairwise *orthogonal* if
 we have the inner product `⟨vᵢ, vⱼ⟩ = 0` whenever `|i - j| ≥ 1` (i.e., if every pair of
@@ -77,7 +86,7 @@ vectors is orthogonal). This is equivalent to the vectors' Gram matrix being dia
 - `k::Int`: the `k`-orthogonality parameter. (Necessarily `1`.)
 
 # Supertype Hierarchy
-_Orthogonality <: _KOrthogonality <: Any
+[`_Orthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
@@ -104,14 +113,19 @@ This constant is used to represent the property of pairwise orthogonality for a 
 of vectors and should always be used in favor of instantiating a new object with
 `_Orthogonality()` every time.
 
-[TODO: Justify further]
+# Notes
+Simply by definition, we are certain that the `k` property of any [`_Orthogonality`](@ref)
+instance will always be `1`, so given that the struct is immutable and we do not intend to
+add any other distinguishing fields/properties, it is idiomatic to define this sort of
+singleton instance for universal use. This design choice also avoids unnecessary allocations
+(although any overhead will be negligible in practice).
 """
 const _ORTHOGONALITY = _Orthogonality()
 
 """
     struct _QuasiOrthogonality
 
-Represents the property of quasi-orthogonality for a collection of vectors.
+The property of quasi-orthogonality for a collection of vectors.
 
 Recall that an (ordered) collection of vectors `v₁, v₂, ..., vₙ` is said to be
 *quasi-orthogonal* if we have the inner product `⟨vᵢ, vⱼ⟩ = 0` whenever `|i - j| ≥ 2` (i.e.,
@@ -122,7 +136,7 @@ the vectors' Gram matrix being tridiagonal [JP25; p. 313](@cite).
 - `k::Int`: the `k`-orthogonality parameter. (Necessarily `2`.)
 
 # Supertype Hierarchy
-_QuasiOrthogonality <: _KOrthogonality <: Any
+[`_QuasiOrthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
@@ -145,18 +159,23 @@ end
 
 A singleton instance of the semantically unique [`_QuasiOrthogonality`](@ref) type.
 
-This constant is used to represents the property of quasi-orthogonality for a collection of
+This constant is used to represent the property of quasi-orthogonality for a collection of
 vectors and should always be used in favor of instantiating a new object with
 `_QuasiOrthogonality()` every time.
 
-[TODO: Justify further]
+# Notes
+Simply by definition, we are certain that the `k` property of any
+[`_QuasiOrthogonality`](@ref) instance will always be `2`, so given that the struct is
+immutable and we do not intend to add any other distinguishing fields/properties, it is
+idiomatic to define this sort of singleton instance for universal use. This design choice
+also avoids unnecessary allocations (although any overhead will be negligible in practice).
 """
 const _QUASI_ORTHOGONALITY = _QuasiOrthogonality()
 
 """
     struct _WeakOrthogonality
 
-Represents the property of "weak orthogonality" for a collection of vectors.
+The property of "weak orthogonality" for a collection of vectors.
 
 In particular, "weak orthogonality" is an *ad hoc* term used to refer to the property of
 `k`-orthogonality for `k > 2`. Recall that an (ordered) collection of vectors
@@ -169,23 +188,25 @@ orthogonal). This is equivalent to the vectors' Gram matrix having bandwidth at 
     `2`.)
 
 # Supertype Hierarchy
-_WeakOrthogonality <: _KOrthogonality <: Any
+[`_WeakOrthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
 
 # Constructors
-- `_WeakOrthogonality(k::Int)`: constructs a [`_WeakOrthogonality`](@ref) object with the
-    given `k`-orthogonality parameter. Throws a `DomainError` if `k <= 2`.
+- `_WeakOrthogonality(k::Integer)`: constructs a [`_WeakOrthogonality`](@ref) object with
+    the given `k`-orthogonality parameter, casting it to an `Int` for type stability. Throws
+    a `DomainError` if `k <= 2`.
 
 # Notes
 The term "weak orthogonality" is not standard terminology in the literature, but it is used
 here to emphasize the weaker nature of this property compared to orthogonality and
 quasi-orthogonality. It is an *ad hoc* term coined for this module and is not intended to
 be formally introduced in the broader literature. See also the documentation for parent type
-[`_KOrthogonality`](@ref) for further discussion of this topic.
+[`_KOrthogonality`](@ref) for further discussion of this topic, as well as justification for
+enforcing the `k` field to be an `Int` rather than the more generic `Integer`.
 """
 struct _WeakOrthogonality <: _KOrthogonality
     k::Int
 
-    function _WeakOrthogonality(k::Int)
+    function _WeakOrthogonality(k::Integer)
         if k <= 2
             throw(
                 DomainError(
@@ -194,7 +215,7 @@ struct _WeakOrthogonality <: _KOrthogonality
             )
         end
 
-        return new(k)
+        return new(Int(k))
     end
 end
 
@@ -207,7 +228,7 @@ When searching for a `k`-orthogonal *S*-basis of a given Laplacian eigenspace, t
 values to which our `k` parameter belongs informs our choice of algorithm.
 
 # Arguments
-- `k::Int`: the `k`-orthogonality parameter to classify. Must be a positive integer.
+- `k::Integer`: the `k`-orthogonality parameter to classify. Must be a positive integer.
 
 # Returns
 - `::_KOrthogonality`: An instance of a concrete [`_KOrthogonality`](@ref) subtype
@@ -235,7 +256,7 @@ SDiagonalizability._WeakOrthogonality(13)
 See the documentation for [`_find_k_orthogonal_basis`](@ref) for further details on how this
 function is used in the context of finding a `k`-orthogonal basis.
 """
-function _classify_orthogonality_property(k::Int)
+function _classify_orthogonality_property(k::Integer)
     k < 1 && throw(DomainError(k, "k-orthogonality parameter must be a positive integer"))
 
     if k == 1

--- a/src/factories/orthogonality_properties.jl
+++ b/src/factories/orthogonality_properties.jl
@@ -22,7 +22,7 @@ values of `k`. For each family of values, we apply a separate algorithm to deter
 there exists a permutation of a given collection of vectors that induces `k`-orthogonality.
 
 # Interface
-Concrete subtypes of [`_KOrthogonality`](@ref) **must** implement the following properties:
+Concrete subtypes of `_KOrthogonality` **must** implement the following properties:
 - `k::Int`: the `k`-orthogonality parameter.
 
 `k` need not necessarily be a field of the subtype (especially in the case of single-value
@@ -42,8 +42,8 @@ minimization algorithm, it may seem prudent to ask why we do not type the `k` fi
 `UInt8` instead of `Int`. An equally compelling argument can be made to type it as `Integer`
 for genericity as well. However, many methods (both within this module and externally) often
 expect `Int`-typed parameters, so we settle on `Int` as our field type. However, in any
-constructors/factories of [`_KOrthogonality`](@ref) subtypes, we allow the `k`-orthogonality
-input parameter to be any generic `Integer`, simply casting it to an `Int` later on.
+constructors/factories of `_KOrthogonality` subtypes, we allow the `k`-orthogonality input
+parameter to be any generic `Integer`, simply casting it to an `Int` later on.
 
 On that note, the stipulation in the interface contract that `k` be an accessible property
 even for semantically unique types like [`_Orthogonality`](@ref) and
@@ -51,11 +51,11 @@ even for semantically unique types like [`_Orthogonality`](@ref) and
 by [`_find_k_orthogonal_basis`](@ref). (Rather, the type itself—which already implicitly
 encodes the value of `k`—directly informs the choice of algorithm in said function.)
 However, we require it nonetheless for the sake of consistency future extensibility, just in
-case the API is later modified to require more generic handling of [`_KOrthogonality`](@ref)
+case the API is later modified to require more generic handling of `_KOrthogonality`
 instances whose specific subtypes are not known based on their `k`-orthogonality parameter.
 
 Another design choice worth scrutinizing is the "`_WeakOrthogonality`" name. "Orthogonality"
-is a term as old as time and "quasi-orthogonality" too has risen to prominence in recent
+is a term as old as time, and "quasi-orthogonality" too has risen to prominence in recent
 years (e.g., [JP25; p. 313](@cite)), but "weak orthogonality," strictly speaking, is not
 standard terminology. We have taken the liberty of coining it here for `k > 2` to emphasize
 its weaker nature compared to orthogonality and quasi-orthogonality. That said, we make no
@@ -69,7 +69,7 @@ collection). Rather, we use it when determining whether a large, linearly depend
 vectors contains an `k`-orthogonal independent spanning subset. This is still related to the
 long-standing matrix bandwidth minimization problem, but it differs in that we can take
 advantage of dynamic programming techniques when recursively searching for such a subset.
-(See the documentation for [`_find_k_orthogonal_basis`](@ref) for further details.)
+(See the [`_find_k_orthogonal_basis`](@ref) documentation for more details.)
 """
 abstract type _KOrthogonality end
 
@@ -86,7 +86,7 @@ vectors is orthogonal). This is equivalent to the vectors' Gram matrix being dia
 - `k::Int`: the `k`-orthogonality parameter. (Necessarily `1`.)
 
 # Supertype Hierarchy
-[`_Orthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
+`_Orthogonality` <: [`_KOrthogonality`](@ref) <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
@@ -136,7 +136,7 @@ the vectors' Gram matrix being tridiagonal [JP25; p. 313](@cite).
 - `k::Int`: the `k`-orthogonality parameter. (Necessarily `2`.)
 
 # Supertype Hierarchy
-[`_QuasiOrthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
+`_QuasiOrthogonality` <: [`_KOrthogonality`](@ref) <: Any
 
 # Notes
 Since this type is semantically unique inasmuch as it simply encodes the information
@@ -188,12 +188,12 @@ orthogonal). This is equivalent to the vectors' Gram matrix having bandwidth at 
     `2`.)
 
 # Supertype Hierarchy
-[`_WeakOrthogonality`](@ref) <: [`_KOrthogonality`](@ref) <: Any
+`_WeakOrthogonality` <: [`_KOrthogonality`](@ref) <: Any
 
 # Constructors
-- `_WeakOrthogonality(k::Integer)`: constructs a [`_WeakOrthogonality`](@ref) object with
-    the given `k`-orthogonality parameter, casting it to an `Int` for type stability. Throws
-    a `DomainError` if `k <= 2`.
+- `_WeakOrthogonality(k)`: constructs a `_WeakOrthogonality` object with the given
+    `k`-orthogonality parameter, casting it to an `Int` for type stability. Throws a
+    `DomainError` if `k <= 2`.
 
 # Notes
 The term "weak orthogonality" is not standard terminology in the literature, but it is used
@@ -253,7 +253,7 @@ SDiagonalizability._WeakOrthogonality(13)
 ```
 
 # Notes
-See the documentation for [`_find_k_orthogonal_basis`](@ref) for further details on how this
+See the [`_find_k_orthogonal_basis`](@ref) documentation for more details on how this
 function is used in the context of finding a `k`-orthogonal basis.
 """
 function _classify_orthogonality_property(k::Integer)

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -4,12 +4,28 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Add docstrings to this file, and some comments to the structs and associated methods
+# TODO: Should I add a note in the corresponding docstring every time I use an `@assert`?
 
 """
     struct SpectrumIntegralResult
 
-TODO: Write here
+Data on whether a matrix is spectrum integral (i.e., whether its eigenvalues are integers).
+
+This struct also contains a map from each eigenvalue to its multiplicity, provided that the
+eigenvalues are indeed all integers. (Otherwise, the associated field is simply `nothing`.)
+
+# Fields
+- `matrix::Matrix{Int}`: the matrix whose eigenvalues and their integrality are of interest.
+- `spectrum_integral::Bool`: whether the eigenvalues of `matrix` are all integers.
+- `multiplicities::Union{Nothing,OrderedDict{Int,Int}}`: a map from each eigenvalue to its
+    multiplicity, sorted first by ascending multiplicity then by ascending eigenvalue. (This
+    field is `nothing` if `spectrum_integral` is false.)
+
+# Notes
+If an undirected graph with integer edge weights is `{-1,0,1}`-diagonalizable (or, more
+restrictively, `{-1,1}`-diagonalizable), then its Laplacian matrix has integer eigenvalues
+[JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
+step in this package's principal *S*-bandwidth minimization algorithm.
 """
 struct SpectrumIntegralResult
     matrix::Matrix{Int}
@@ -24,7 +40,7 @@ struct SpectrumIntegralResult
         if spectrum_integral && isnothing(multiplicities)
             throw(
                 ArgumentError(
-                    "`multiplicities` is only nothing as a sentinel value " *
+                    "`multiplicities` is only `nothing` as a sentinel value " *
                     "when `spectrum_integral` is false.",
                 ),
             )
@@ -37,7 +53,21 @@ end
 """
     struct _Eigenspace01Neg
 
-TODO: Write here
+Data on an eigenspace of some Laplacian matrix with respect to the `{-1,0,1}`-spectrum.
+
+# Fields
+- `dimension::Int`: the dimension of the eigenspace.
+- `eigvecs_01neg::AbstractMatrix{Int}`: the `{-1,0,1}`-eigenvectors in this eigenspace,
+    stored as columns of a matrix.
+- `indices_1neg::Vector{Int}`: the indices of all `{-1,1}`-columns in `eigvecs_01neg`.
+- `basis_01neg::Union{Nothing,Matrix{Int}}`: a `{-1,0,1}`-basis for the eigenspace, if one
+    exists. (This field is `nothing` if no such basis exists.)
+- `basis_1neg::Union{Nothing,Matrix{Int}}`: a `{-1,1}`-basis for the eigenspace, if one
+    exists. (This field is `nothing` if no such basis exists.)
+
+# Notes
+TODO: [No eigenvalue/matrix, deterministic but arbitrary selection of bases, re-route to
+documentation elsewhere for `Vector{Int}` over `BitVector` justification]
 """
 struct _Eigenspace01Neg
     dimension::Int
@@ -50,7 +80,7 @@ end
 """
     struct LaplacianSpectrum01Neg
 
-TODO: Write here
+Data on the `{-1,0,1}`-spectrum of some Laplacian matrix.
 """
 struct LaplacianSpectrum01Neg
     laplacian_matrix::Matrix{Int}
@@ -67,14 +97,13 @@ function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
     if name != :eigspaces_01neg && name in fieldnames(LaplacianSpectrum01Neg)
         value = getfield(obj, name)
     elseif getfield(obj, :diagonalizable_01neg)
+        #= `eigspaces_01neg` is only `nothing` when `diagonalizable_01neg` is false, so we
+        explicitly assert its type here for compiler inference during static analysis. =#
         eigspaces_01neg = getfield(obj, :eigspaces_01neg)
-
-        #= For compiler inference during static analysis. We choose to assert rather than
-        throw an error because this struct is not part of the public API; hence, any failure
-        to meet this condition indicates a developer error. =#
         @assert !isnothing(eigspaces_01neg)
 
         name == :multiplicities && (name = :dimension)
+
         value = OrderedDict(
             eigval => getfield(eigspace, name) for (eigval, eigspace) in eigspaces_01neg
         )
@@ -85,12 +114,9 @@ function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
     return value
 end
 
-#= TODO: (1) Actually implement this sorting in `src/s_bandwidth.jl` once we write it. First
+#= TODO: Actually implement this sorting in `src/s_bandwidth.jl` once we write it. First
 check if it is sorted, raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not, then
 sort. This will be slower if the input is not sorted but faster if it is (as we expect). =#
-
-#= TODO: (2) Perhaps some of this documentation go in the `SpectrumIntegralResult`
-docstring instead, although I am leaning towards keeping it here. =#
 """
     check_spectrum_integrality(A)
 
@@ -106,9 +132,9 @@ constructed as well.
 - `::SpectrumIntegralResult`: a struct containing the following fields:
     - `matrix::Matrix{Int}`: a (casted) copy of `A`, avoiding shared mutability.
     - `spectrum_integral::Bool`: whether the eigenvalues of `A` are integers.
-    - `multiplicities::Union{Nothing,OrderedDict{Int,Int}}`: a map from eigenvalues to
-        multiplicities, sorted first by ascending multiplicity then by ascending eigenvalue.
-        (This field is `nothing` if the eigenvalues are not all integers.)
+    - `multiplicities::Union{Nothing,OrderedDict{Int,Int}}`: a map from each eigenvalue to
+        its multiplicity, sorted first by ascending multiplicity then by ascending
+        eigenvalue. (This field is `nothing` if the eigenvalues are not all integers.)
 
 # Examples
 Confirm that the rotation matrix by `π/2` radians counterclockwise is not spectrum integral
@@ -209,7 +235,7 @@ function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
         multiplicities = nothing
     end
 
-    SpectrumIntegralResult(A_copy, spectrum_integral, multiplicities)
+    return SpectrumIntegralResult(A_copy, spectrum_integral, multiplicities)
 end
 
 """
@@ -217,9 +243,13 @@ end
 
 Return a (not necessarily unique) independent spanning subset of the columns of `A`.
 
-Computing a QR decomposition of `A`, the scaling coefficients from the orthogonalization
-process are used to determine the rank (rather than recompute it with an SVD), while the
-pivots are used to extract a spanning set of independent columns.
+Computing a rank-revealing (pivoted) QR decomposition of `A`, the scaling coefficients from
+the orthogonalization process are used to determine the rank (rather than recompute it with
+an SVD), while the pivots are used to extract a spanning set of independent columns.
+
+The rank-revealing Businger–Golub QR algorithm is used for the pivoting strategy, appending
+the "most independent" column with respect to the current set of pivots at each step via
+Householder transformations [BG65; pp. 269--70](@cite).
 
 # Arguments
 - `A::AbstractMatrix{T<:Integer}`: the matrix whose independent columns to extract.
@@ -252,26 +282,34 @@ julia> SDiagonalizability._extract_independent_cols(A)
 ```
 
 # Notes
-The somewhat rare (although certainly far from unorthodox) choice of QR decomposition for
-our purposes merits discussion. [TODO: Write here]
+Since we already need a pivoted QR decomposition to identify independent columns of `A` (or,
+rather, to order the columns in such a way that the first `rank(A)` ones are guaranteed to
+be independent), it makes sense to use data from the resulting factorization object to
+compute the rank of `A` rather than compute a separate SVD. We thus count the nonzero scaling
+coefficients—that is, the diagonal entries of the `R` matrix in `A = QR`—to determine the
+rank, similarly to how we count the nonzero singular values in an SVD.
 
-TODO: Also discuss why we can't just transpose first (gets us independent rows)
-
-TODO: Discuss unusual use of `_rank_rtol`
+It is worth noting that we manually specify a higher relative tolerance for this rank
+computation. Further discussion can be found in the [`_rank_rtol`](@ref) documentation, but
+in short, a critical part of the formula for `LinearAlgebra.rank`'s default `rtol`
+uses the minimum dimension of the input matrix. This may result in rank overestimation for
+tall-and-skinny and short-and-fat matrices (precisely the type we expect to encounter when
+dealing with all `{-1,0,1}`-eigenvectors of a Laplacian matrix, which is the intended use
+case of this helper function in this package). Our replacement tolerance, on the other hand,
+is a widely accepted standard in numerical analysis which uses the maximum dimension instead
+[PTVF07; p. 795](@cite).
 """
 function _extract_independent_cols(A::AbstractMatrix{<:Integer})
-    # Cast to a dense floating-point matrix to enable optimizations in `LinearAlgebra.qr`
-    A_float = Matrix{Float64}(A)
+    F = qr(A, ColumnNorm())
+    rtol = _rank_rtol(A) # Use a higher tolerance (NumPy's/MATLAB's) than Julia's default
 
-    # Factorize `A = QR` for some real unitary matrix `Q` and upper triangular matrix `R`
-    F = qr(A_float, ColumnNorm())
-    pivots = F.p # The first `rank(A)` pivots correspond to independent columns of `A`
-    ortho_coefs = diag(F.R) # Scaling factors of the columns of the `Q` matrix
+    #= In Julia 1.12+, `LinearAlgebra.rank` dispatches to a method that re-uses an existing
+    QR decomposition. For compatibility with v1.10–1.11, we manually define it ourselves in
+    `src/utils.jl`. =#
+    r = rank(F; rtol=rtol)
+    pivots = F.p[1:r] # The first `rank(A)` pivots correspond to independent columns of `A`
 
-    tol = _rank_rtol(A_float) * maximum(abs, ortho_coefs) # TODO: Add inline comment
-    r = count(x -> abs(x) > tol, ortho_coefs) # The rank of `A` within floating-point error
-
-    return A[:, pivots[1:r]] # An independent spanning subset of the columns of `A`
+    return A[:, pivots]
 end
 
 """
@@ -279,22 +317,24 @@ end
 
 Find the indices of `{-1,1}`-eigenvectors given a map of eigenspaces.
 
-More precisely, given a map from each eigenvalue to all {-1,0,1}-vectors in the associated
+More precisely, given a map from each eigenvalue to all `{-1,0,1}`-vectors in the associated
 eigenspace, this function returns a map from each eigenvalue to the indices of the
-{-1,1}-vectors in each value from the input map.
+`{-1,1}`-vectors in each value from the input map.
 
 # Arguments
-- `eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int}}`: a map from eigenvalues to
-    eigenspaces, TODO: Write here
+- `eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int}}`: a map from each eigenvalue to
+    all `{-1,0,1}`-eigenvectors in the associated eigenspace.
 
 # Returns
-- `::AbstractDict{Int,Vector{Int}}`: TODO: Write here
+- `::AbstractDict{Int,Vector{Int}}`: a map from each eigenvalue `eigval` to the indices of
+    the `{-1,1}`-columns in `eigvecs_01neg[eigval]`.
 
 # Examples
 TODO: Write here
 
 # Notes
-TODO: Justify decision to use `Vector{Int}` rather than `BitVector` for the indices
+TODO: Justify decision to use `Vector{Int}` rather than `BitVector` for the indices (that
+is, memory efficiency when very few columns have entries exclusively from `{-1,1}`).
 """
 function _find_indices_1neg(eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int}})
     #= The order of the Laplacian matrix. Accessing the zero key is safe, as every
@@ -304,12 +344,12 @@ function _find_indices_1neg(eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int
     # Only even-ordered Laplacians have non-kernel {-1,1}-eigenvectors
     if n % 2 == 0 # Check all eigenspaces for {-1,1}-eigenvectors
         indices_1neg = Dict(
-            eigval => findall(v -> all(v .!= 0), eachcol(eigvecs)) for
+            eigval => findall(v -> !any(iszero, v), eachcol(eigvecs)) for
             (eigval, eigvecs) in eigvecs_01neg
         )
     else # Only check the kernel for {-1,1}-eigenvectors
         indices_1neg = Dict(eigval => Int[] for eigval in keys(eigvecs_01neg))
-        indices_1neg[0] = findall(v -> all(v .!= 0), eachcol(eigvecs_01neg[0]))
+        indices_1neg[0] = findall(v -> !any(iszero, v), eachcol(eigvecs_01neg[0]))
     end
 
     return indices_1neg # Indices of the {-1,0,1}-eigenvectors without 0's
@@ -318,26 +358,27 @@ end
 """
     laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
 
-Compute data on the {-1,0,1}-spectrum of some Laplacian matrix `L`.
+Compute data on the `{-1,0,1}`- and `{-1,1}`-spectrum of some Laplacian matrix `L`.
 
 TODO: Write here
 
 # Arguments
-- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix on whose `{-1,0,1}`-spectrum we are
-    to compute data.
+- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix in whose `{-1,0,1}`- and
+    `{-1,1}`-spectrum we are interested.
 
 # Returns
 - `::LaplacianSpectrum01Neg`: a struct containing the following fields:
     - `laplacian_matrix::Matrix{Int}`: a (casted) copy of `L`, avoiding shared mutability.
-    - `diagonalizable_01neg::Bool`: whether the Laplacian is {-1,0,1}-diagonalizable.
-    - `diagonalizable_1neg::Bool`: whether the Laplacian is {-1,1}-diagonalizable.
+    - `diagonalizable_01neg::Bool`: whether the Laplacian is `{-1,0,1}`-diagonalizable.
+    - `diagonalizable_1neg::Bool`: whether the Laplacian is `{-1,1}`-diagonalizable.
     - `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: TODO: Write here
 
 # Examples
 TODO: Write here
 
 # Notes
-TODO: Include notes on the relevant properties of each type of Laplacian matrix
+TODO: Include notes on the relevant properties of each type of Laplacian matrix. Also,
+reference documentation on the `LaplacianSpectrum01Neg` struct.
 """
 function laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
     TL = _cast_to_typed_laplacian(L)
@@ -372,6 +413,9 @@ function _typed_laplacian_spectra_01neg(TL::_EmptyGraphLaplacian)
     L = TL.matrix
     n = size(L, 1)
 
+    #= TODO: Static analysis with JET.jl reads this as either a `Matrix` or a `Vector{Any}`,
+    generating a warning given the latter possibility. Will JET complain about a potential
+    `MethodError` if we type this as `::Matrix` (in which case we'll need an `@assert`)? =#
     kernel_eigvecs_01neg = hcat(_pot_kernel_eigvecs_01neg(n)...)
     eigvecs_01neg = Dict(0 => kernel_eigvecs_01neg)
     indices_1neg = _find_indices_1neg(eigvecs_01neg)
@@ -480,8 +524,12 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
         return LaplacianSpectrum01Neg(L, false, false, nothing)
     end
 
-    n = size(L, 1)
+    #= `multiplicities` is only `nothing` when `spectrum_integral` is false, so we
+    explicitly assert its type here for compiler inference during static analysis. =#
     multiplicities = res.multiplicities
+    @assert !isnothing(multiplicities)
+
+    n = size(L, 1)
     eigvals_nonzero = filter(!iszero, keys(multiplicities))
     eigvecs_01neg = Dict{Int,AbstractMatrix{Int}}(
         # Initialize resizeable matrices to store an unknown number of eigenvectors
@@ -511,10 +559,11 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
 
     indices_1neg = _find_indices_1neg(eigvecs_01neg)
 
+    # TODO: Comment on why we type the values
     bases_01neg = Dict{Int,Union{Nothing,Matrix{Int}}}(
         eigval => _extract_independent_cols(vecs) for (eigval, vecs) in eigvecs_01neg
     )
-    bases_1neg = Dict(
+    bases_1neg = Dict{Int,Union{Nothing,Matrix{Int}}}(
         eigval => _extract_independent_cols(vecs[:, indices_1neg[eigval]]) for
         (eigval, vecs) in eigvecs_01neg
     )
@@ -524,9 +573,13 @@ function _typed_laplacian_spectra_01neg(TL::_ArbitraryGraphLaplacian)
     #= If they exist, find a {-1,0,1}- and {-1,1}-basis for each non-kernel eigenspace.
     {-1,1}-bases are preferable, so they take priority whenever they exist. =#
     for eigval in eigvals_nonzero
-        multiplicity = multiplicities[eigval]
+        # TODO: Comment on the `@assert`'s for compiler inference during static analysis
         pot_basis_01neg = bases_01neg[eigval]
+        @assert !isnothing(pot_basis_01neg)
         pot_basis_1neg = bases_1neg[eigval]
+        @assert !isnothing(pot_basis_1neg)
+
+        multiplicity = multiplicities[eigval]
 
         if size(pot_basis_01neg, 2) < multiplicity # The eigenspace has no {-1,0,1}-basis
             bases_01neg[eigval] = bases_1neg[eigval] = nothing

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -81,12 +81,33 @@ end
     struct LaplacianSpectrum01Neg
 
 Data on the `{-1,0,1}`-spectrum of some Laplacian matrix.
+
+TODO: Write here
+
+# Fields
+- `laplacian_matrix::Matrix{Int}`: the Laplacian matrix.
+- `diagonalizable_01neg::Bool`: whether the Laplacian is `{-1,0,1}`-diagonalizable.
+- `diagonalizable_1neg::Bool`: whether the Laplacian is `{-1,1}`-diagonalizable.
+- `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: a map from each
+    eigenvalue to its corresponding `{-1,0,1}`-spectrum, sorted first by ascending
+    multiplicity then by ascending eigenvalue. (This field is `nothing` if and only if the
+    Laplacian is not spectrum integral, which implies that `diagonalizable_01neg` is also
+    false [JP25; p. 312](@cite). However, this field contains data even when
+    `diagonalizable_01neg` is false in the case that `laplacian_matrix` has *some*
+    `{-1,0,1}`-eigenvectors but lacks spanning `{-1,0,1}`-bases for all eigenspaces.)
+
+# Properties
+TODO: Write here
+
+# Notes
+TODO: Write here
 """
 struct LaplacianSpectrum01Neg
     laplacian_matrix::Matrix{Int}
     diagonalizable_01neg::Bool
     diagonalizable_1neg::Bool
     eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}
+    # TODO: Add a constructor that validates {-1.0,1}-spectra?
 end
 
 function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
@@ -108,6 +129,7 @@ function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
             eigval => getfield(eigspace, name) for (eigval, eigspace) in eigspaces_01neg
         )
     else
+        # TODO: Is thi the desired behavior? We might want data even when not diagonalizable
         value = nothing
     end
 
@@ -321,6 +343,9 @@ More precisely, given a map from each eigenvalue to all `{-1,0,1}`-vectors in th
 eigenspace, this function returns a map from each eigenvalue to the indices of the
 `{-1,1}`-vectors in each value from the input map.
 
+It is, of course, assumed that the input map indeed contains only `{-1,0,1}`-matrices as
+values, and that it contains `0` as a key.
+
 # Arguments
 - `eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int}}`: a map from each eigenvalue to
     all `{-1,0,1}`-eigenvectors in the associated eigenspace.
@@ -333,6 +358,8 @@ eigenspace, this function returns a map from each eigenvalue to the indices of t
 TODO: Write here
 
 # Notes
+
+
 TODO: Justify decision to use `Vector{Int}` rather than `BitVector` for the indices (that
 is, memory efficiency when very few columns have entries exclusively from `{-1,1}`).
 """

--- a/src/laplacian_spectra.jl
+++ b/src/laplacian_spectra.jl
@@ -4,8 +4,6 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Should I add a note in the corresponding docstring every time I use an `@assert`?
-
 """
     struct SpectrumIntegralResult
 
@@ -56,7 +54,7 @@ end
 Data on an eigenspace of some Laplacian matrix with respect to the `{-1,0,1}`-spectrum.
 
 # Fields
-- `dimension::Int`: the dimension of the eigenspace.
+- `multiplicity::Int`: the multiplicity of the eigenspace.
 - `eigvecs_01neg::AbstractMatrix{Int}`: the `{-1,0,1}`-eigenvectors in this eigenspace,
     stored as columns of a matrix.
 - `indices_1neg::Vector{Int}`: the indices of all `{-1,1}`-columns in `eigvecs_01neg`.
@@ -66,11 +64,19 @@ Data on an eigenspace of some Laplacian matrix with respect to the `{-1,0,1}`-sp
     exists. (This field is `nothing` if no such basis exists.)
 
 # Notes
-TODO: [No eigenvalue/matrix, deterministic but arbitrary selection of bases, re-route to
-documentation elsewhere for `Vector{Int}` over `BitVector` justification]
+This helper struct is, above all else, used for the sake of efficient data storage in
+user-facing structs, with the [`LaplacianSpectrum01Neg`](@ref) constructor flattening data
+stored across several `_Eigenspace01Neg` instances into top-level fields. This justifies the
+exclusion of the `eigval` field, which is redundant in the context of
+[`LaplacianSpectrum01Neg`](@ref) (the keys of the `eigspaces_01neg::{Int,_Eigenspace01Neg}`
+map already specify the eigenvalues).
+
+See the [`_find_indices_1neg`](@ref) documentation if seeking justification for why the
+`indices_1neg` field is a `Vector{Int}` rather than a `BitVector`. (In short, very few
+columns have entries exclusively from `{-1,1}`, so `Vector{Int}`'s consume less memory.)
 """
 struct _Eigenspace01Neg
-    dimension::Int
+    multiplicity::Int
     eigvecs_01neg::AbstractMatrix{Int}
     indices_1neg::Vector{Int}
     basis_01neg::Union{Nothing,Matrix{Int}}
@@ -78,67 +84,172 @@ struct _Eigenspace01Neg
 end
 
 """
-    struct LaplacianSpectrum01Neg
+    struct LaplacianSpectrum01Neg{R,S<:R,T<:R,U<:R,V<:R}
 
 Data on the `{-1,0,1}`-spectrum of some Laplacian matrix.
 
-TODO: Write here
+Each instance encapsulates the Laplacian itself, whether the Laplacian is `{-1,0,1}`- and
+`{-1,1}`-diagonalizable, each eigenvalue's multiplicity, and the associated `{-1,0,1}`- and
+`{-1,1}`-eigenvectors, and eigenbases. If the Laplacian is not spectrum integral, then it
+cannot have any `{-1,0,1}`-eigenvectors outside of the kernel [JP25; p. 312](@cite), so much
+of this data is simply `nothing`.
+
+# Type Parameters
+- `R<:Union{Nothing,OrderedDict{Int}}`: the "common upper bound" for all five map-like
+    fields, ensuring that they are either all of the same supertype. Either `Nothing` (if
+    and only if the Laplacian is not spectrum integral, since we cannot map non-integer
+    eigenvalues to data) or `OrderedDict{Int}` (if all eigenvalues are indeed integers).
+- `S<:R`: the type of the `multiplicities` field. Either `Nothing` or an
+    `OrderedDict{Int,Int}`.
+- `T<:R`: the type of the `eigvecs_01neg` field. Either `Nothing` or an
+    `OrderedDict{Int,AbstractMatrix{Int}}`.
+- `U<:R`: the type of the `indices_1neg` field. Either `Nothing` or an
+    `OrderedDict{Int,Vector{Int}}`.
+- `V<:R`: the type of the `bases_01neg` and `bases_1neg` fields. Either `Nothing` or an
+    `OrderedDict{Int,Union{Nothing,Matrix{Int}}}`.
 
 # Fields
 - `laplacian_matrix::Matrix{Int}`: the Laplacian matrix.
 - `diagonalizable_01neg::Bool`: whether the Laplacian is `{-1,0,1}`-diagonalizable.
 - `diagonalizable_1neg::Bool`: whether the Laplacian is `{-1,1}`-diagonalizable.
-- `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: a map from each
-    eigenvalue to its corresponding `{-1,0,1}`-spectrum, sorted first by ascending
-    multiplicity then by ascending eigenvalue. (This field is `nothing` if and only if the
-    Laplacian is not spectrum integral, which implies that `diagonalizable_01neg` is also
-    false [JP25; p. 312](@cite). However, this field contains data even when
-    `diagonalizable_01neg` is false in the case that `laplacian_matrix` has *some*
-    `{-1,0,1}`-eigenvectors but lacks spanning `{-1,0,1}`-bases for all eigenspaces.)
+- `multiplicities::S`: a map from each eigenvalue to its multiplicity, sorted first by
+    ascending multiplicity then by ascending eigenvalue. (If the Laplacian is not spectrum
+    integral, this field is `nothing`.)
+- `eigvecs_01neg::T`: a map from each eigenvalue to its `{-1,0,1}`-eigenvectors, stored as
+    columns of a matrix. (If the Laplacian is not spectrum integral, this field is
+    `nothing`.)
+- `indices_1neg::U`: a map from each eigenvalue to the indices of the `{-1,1}`-columns in
+    `eigvecs_01neg[eigval]`. (If the Laplacian is not spectrum integral, this field is
+    `nothing`.)
+- `bases_01neg::V`: a map from each eigenvalue to a `{-1,0,1}`-basis for the corresponding
+    eigenspace if one exists, or to `nothing` otherwise. (If the Laplacian is not spectrum
+    integral, this field is `nothing`.)
+- `bases_1neg::V`: a map from each eigenvalue to a `{-1,1}`-basis for the corresponding
+    eigenspace if one exists, or to `nothing` otherwise. (If the Laplacian is not spectrum
+    integral, this field is `nothing`.)
 
-# Properties
-TODO: Write here
+# Constructors
+- `LaplacianSpectrum01Neg(
+    laplacian_matrix, diagonalizable_01neg, diagonalizable_1neg, eigspaces_01neg
+)`: constructs a `LaplacianSpectrum01Neg` instance from the given Laplacian matrix and
+    associated data on its `{-1,0,1}`-eigenspaces. When `eigspaces_01neg` is not `nothing`
+    (indicating spectrum integrality), this constructors flattens the data stored in the
+    [`_Eigenspace01Neg`](@ref) instances and exposes it via top-level fields. (See the
+    [`_Eigenspace01Neg`](@ref) documentation for more details.)
 
 # Notes
-TODO: Write here
+TODO: Discuss potential use cases for this beyond the `s_bandwidth` algorithm
 """
-struct LaplacianSpectrum01Neg
+struct LaplacianSpectrum01Neg{R<:Union{Nothing,OrderedDict{Int}},S<:R,T<:R,U<:R,V<:R}
     laplacian_matrix::Matrix{Int}
     diagonalizable_01neg::Bool
     diagonalizable_1neg::Bool
-    eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}
-    # TODO: Add a constructor that validates {-1.0,1}-spectra?
-end
+    multiplicities::S
+    eigvecs_01neg::T
+    indices_1neg::U
+    bases_01neg::V
+    bases_1neg::V
 
-function Base.getproperty(obj::LaplacianSpectrum01Neg, name::Symbol)
-    if name == :dimension || !(name in fieldnames(_Eigenspace01Neg))
-        error("type $(typeof(obj)) has no field $name")
+    function LaplacianSpectrum01Neg(
+        laplacian_matrix::Matrix{Int},
+        diagonalizable_01neg::Bool,
+        diagonalizable_1neg::Bool,
+        eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}},
+    )
+        #= {-1,1}-diagonalizability is a strict subset of {-1,0,1}-diagonalizability, so any
+        matrix that is {-1,1}-diagonalizable must also be {-1,0,1}-diagonalizable. =#
+        if diagonalizable_1neg && !diagonalizable_01neg
+            throw(
+                ArgumentError(
+                    "If `diagonalizable_1neg` is `true`, then `diagonalizable_01neg` " *
+                    "must be `true` as well",
+                ),
+            )
+        end
+
+        #= Call a helper that dispatches to different methods depending on the type of
+        `eigspaces_01neg`. The eigenspace data is flattened therein. =#
+        return (_helper_constructor(
+            laplacian_matrix, diagonalizable_01neg, diagonalizable_1neg, eigspaces_01neg
+        ))
     end
 
-    if name != :eigspaces_01neg && name in fieldnames(LaplacianSpectrum01Neg)
-        value = getfield(obj, name)
-    elseif getfield(obj, :diagonalizable_01neg)
-        #= `eigspaces_01neg` is only `nothing` when `diagonalizable_01neg` is false, so we
-        explicitly assert its type here for compiler inference during static analysis. =#
-        eigspaces_01neg = getfield(obj, :eigspaces_01neg)
-        @assert !isnothing(eigspaces_01neg)
+    function _helper_constructor(
+        laplacian_matrix::Matrix{Int},
+        diagonalizable_01neg::Bool,
+        diagonalizable_1neg::Bool,
+        ::Nothing,
+    )
+        #= `eigspaces_01neg` is `nothing` if and only if the Laplacian is not spectrum
+        integral, in which case the Laplacian cannot be {-1,0,1}-diagonalizable either. =#
+        if diagonalizable_01neg
+            throw(
+                ArgumentError(
+                    "If `eigspaces_01neg` is `nothing`, then `diagonalizable_01neg` must " *
+                    " be false",
+                ),
+            )
+        end
 
-        name == :multiplicities && (name = :dimension)
+        R = S = T = U = V = Nothing
 
-        value = OrderedDict(
-            eigval => getfield(eigspace, name) for (eigval, eigspace) in eigspaces_01neg
+        #= We call `S()`, `T()`, etc. to signify the relationship between the fields and
+        their type parameters, but this is really just equivalent to passing `nothing`. =#
+        return new{R,S,T,U,V}(
+            laplacian_matrix,
+            diagonalizable_01neg,
+            diagonalizable_1neg,
+            S(),
+            T(),
+            U(),
+            V(),
+            V(),
         )
-    else
-        # TODO: Is thi the desired behavior? We might want data even when not diagonalizable
-        value = nothing
     end
 
-    return value
+    function _helper_constructor(
+        laplacian_matrix::Matrix{Int},
+        diagonalizable_01neg::Bool,
+        diagonalizable_1neg::Bool,
+        eigspaces_01neg::OrderedDict{Int,_Eigenspace01Neg},
+    )
+        R = OrderedDict{Int}
+        S = OrderedDict{Int,Int}
+        T = OrderedDict{Int,AbstractMatrix{Int}}
+        U = OrderedDict{Int,Vector{Int}}
+        V = OrderedDict{Int,Union{Nothing,Matrix{Int}}}
+
+        #= Here we flatten the data stored in the `_Eigenspace01Neg` instances to expose it
+        via top-level fields of `LaplacianSpectrum01Neg`. =#
+        multiplicities = S(
+            eigval => eigspace.multiplicity for (eigval, eigspace) in eigspaces_01neg
+        )
+        eigvecs_01neg = T(
+            eigval => eigspace.eigvecs_01neg for (eigval, eigspace) in eigspaces_01neg
+        )
+        indices_1neg = U(
+            eigval => eigspace.indices_1neg for (eigval, eigspace) in eigspaces_01neg
+        )
+        bases_01neg = V(
+            eigval => eigspace.basis_01neg for (eigval, eigspace) in eigspaces_01neg
+        )
+        bases_1neg = V(
+            eigval => eigspace.basis_1neg for (eigval, eigspace) in eigspaces_01neg
+        )
+
+        return new{R,S,T,U,V}(
+            laplacian_matrix,
+            diagonalizable_01neg,
+            diagonalizable_1neg,
+            multiplicities,
+            eigvecs_01neg,
+            indices_1neg,
+            bases_01neg,
+            bases_1neg,
+        )
+    end
 end
 
-#= TODO: Actually implement this sorting in `src/s_bandwidth.jl` once we write it. First
-check if it is sorted, raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not, then
-sort. This will be slower if the input is not sorted but faster if it is (as we expect). =#
 """
     check_spectrum_integrality(A)
 
@@ -152,11 +263,11 @@ constructed as well.
 
 # Returns
 - `::SpectrumIntegralResult`: a struct containing the following fields:
-    - `matrix::Matrix{Int}`: a (casted) copy of `A`, avoiding shared mutability.
-    - `spectrum_integral::Bool`: whether the eigenvalues of `A` are integers.
-    - `multiplicities::Union{Nothing,OrderedDict{Int,Int}}`: a map from each eigenvalue to
-        its multiplicity, sorted first by ascending multiplicity then by ascending
-        eigenvalue. (This field is `nothing` if the eigenvalues are not all integers.)
+    - `matrix`: the `A` matrix, copied to avoid shared mutability.
+    - `spectrum_integral`: whether the eigenvalues of `A` are integers.
+    - `multiplicities`: a map from each eigenvalue to its multiplicity, sorted first by
+        ascending multiplicity then by ascending eigenvalue. (This field is `nothing` if the
+        eigenvalues are not all integers.)
 
 # Examples
 Confirm that the rotation matrix by `π/2` radians counterclockwise is not spectrum integral
@@ -234,14 +345,14 @@ step in this package's principal *S*-bandwidth minimization algorithm.
 It is, perhaps, an odd choice to sort the eigenvalue/multiplicity pairs in this file rather
 than in [`s_bandwidth`](@ref)—after all, in the context of the overarching *S*-bandwidth
 algorithm, this ordering is only ever used to determine which eigenspaces are searched for
-*S*-bases first. However, the inclusion of [`check_spectrum_integrality`](@ref) in the
-public API motivates a consistent, natural ordering of the `multiplicites` map in each
-(potentially user-facing) [`SpectrumIntegralResult`](@ref) instance.
+*S*-bases first. However, the inclusion of `check_spectrum_integrality` in the public API
+motivates a consistent, natural ordering of the `multiplicites` map in each (potentially
+user-facing) [`SpectrumIntegralResult`](@ref) instance.
 
 Of course, we make it a point to still sort `multiplicities` as desired (first by ascending
 multiplicity then by ascending eigenvalue) in `s_bandwidth` itself; this seems more robust
-than relying on [`check_spectrum_integrality`](@ref) to do so or even folding the logic into
-the [`SpectrumIntegralResult`](@ref) inner constructor.
+than relying on `check_spectrum_integrality` to do so or even folding the logic into the
+[`SpectrumIntegralResult`](@ref) inner constructor.
 """
 function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
     A_copy = Matrix{Int}(A) # Avoid shared mutability and cast to `Matrix{Int}`
@@ -355,13 +466,43 @@ values, and that it contains `0` as a key.
     the `{-1,1}`-columns in `eigvecs_01neg[eigval]`.
 
 # Examples
-TODO: Write here
+```jldoctest; setup = :(using SDiagonalizability)
+julia> eigvecs_01neg = Dict(
+           0 => [1  1   1;
+                 1  1   1;
+                 1  1   1;
+                 1  0  -1],
+           2 => [ 1   0;
+                  0   1;
+                 -1  -1;
+                  0   0],
+       )
+Dict{Int64, Matrix{Int64}} with 2 entries:
+  0 => [1 1 1; 1 1 1; 1 1 1; 1 0 -1]
+  2 => [1 0; 0 1; -1 -1; 0 0]
+
+julia> SDiagonalizability._find_indices_1neg(eigvecs_01neg)
+Dict{Int64, Vector{Int64}} with 2 entries:
+  0 => [1, 3]
+  2 => []
+```
 
 # Notes
+It is important to note that this function implicitly assumes that the input map already
+constitutes valid `{-1,0,1}`-spectra for some undirected Laplacian matrix. For instance, the
+assumption that all eigenvectors corresponding to nonzero eigenvalues are orthogonal to the
+all-ones vector (which must be in the kernel) is integral to the correctness of this
+algorithm. Since `_find_indices_1neg` is ultimately but a helper function for
+[`laplacian_spectra_01neg`](@ref), which already validates that the input passed is valid,
+we choose not to double-check it here for performance reasons. (Usually, it would be good
+practice to do so, but the potential sheer size of `eigvecs_01neg`, combined with the
+time-sensitive nature of the algorithm, precludes the possibility in this particular case.)
 
-
-TODO: Justify decision to use `Vector{Int}` rather than `BitVector` for the indices (that
-is, memory efficiency when very few columns have entries exclusively from `{-1,1}`).
+Another design choice worthy of discussion is to encode (per eigenspace) the data on which
+columns have entries exclusively from `{-1,1}` as a `Vector{Int}` rather than a `BitVector`.
+`Vector{Int}`'s become more memory efficient than `BitVector`'s to store indices when the
+density of `true`s is less than `1 / 64`, which is far greater than the proportion of
+`{-1,1}`-columns in most (albeit not all) cases, simply based on our numerical results.
 """
 function _find_indices_1neg(eigvecs_01neg::AbstractDict{Int,<:AbstractMatrix{Int}})
     #= The order of the Laplacian matrix. Accessing the zero key is safe, as every
@@ -387,7 +528,9 @@ end
 
 Compute data on the `{-1,0,1}`- and `{-1,1}`-spectrum of some Laplacian matrix `L`.
 
-TODO: Write here
+The original matrix, whether it is `{-1,0,1}`- and `{-1,1}`-diagonalizable, and further data
+on the eigenvalues and their corresponding `{-1,0,1}`- and `{-1,1}`-eigenvectors are all
+stored in a [`LaplacianSpectrum01Neg`](@ref) instance and returned.
 
 # Arguments
 - `L::AbstractMatrix{<:Integer}`: the Laplacian matrix in whose `{-1,0,1}`- and
@@ -395,17 +538,34 @@ TODO: Write here
 
 # Returns
 - `::LaplacianSpectrum01Neg`: a struct containing the following fields:
-    - `laplacian_matrix::Matrix{Int}`: a (casted) copy of `L`, avoiding shared mutability.
-    - `diagonalizable_01neg::Bool`: whether the Laplacian is `{-1,0,1}`-diagonalizable.
-    - `diagonalizable_1neg::Bool`: whether the Laplacian is `{-1,1}`-diagonalizable.
-    - `eigspaces_01neg::Union{Nothing,OrderedDict{Int,_Eigenspace01Neg}}`: TODO: Write here
+    - `laplacian_matrix`: the `L` matrix, copied to avoid shared mutability.
+    - `diagonalizable_01neg`: whether the Laplacian is `{-1,0,1}`-diagonalizable.
+    - `diagonalizable_1neg`: whether the Laplacian is `{-1,1}`-diagonalizable.
+    - `multiplicities`: a map from each eigenvalue to its multiplicity, sorted first by
+        ascending multiplicity then by ascending eigenvalue. (This field is `nothing` if the
+        Laplacian is not spectrum integral.)
+    - `eigvecs_01neg`: a map from each eigenvalue to its `{-1,0,1}`-eigenvectors. (This
+        field is `nothing` if the Laplacian is not spectrum integral.)
+    - `indices_1neg`: a map from each eigenvalue to the indices of the `{-1,1}`-columns in
+        `eigvecs_01neg[eigval]`. (This field is `nothing` if the Laplacian is not spectrum
+        integral.)
+    - `bases_01neg`: a map from each eigenvalue to a `{-1,0,1}`-basis for the corresponding
+        eigenspace. (This field is `nothing` if the Laplacian is not spectrum integral.)
+    - `bases_1neg`: a map from each eigenvalue to a `{-1,1}`-basis for the corresponding
+        eigenspace. (This field is `nothing` if the Laplacian is not spectrum integral.)
 
 # Examples
-TODO: Write here
+TODO: Add examples
 
 # Notes
-TODO: Include notes on the relevant properties of each type of Laplacian matrix. Also,
-reference documentation on the `LaplacianSpectrum01Neg` struct.
+`laplacian_spectra_01neg` outsources the actual computation logic to the
+[`_typed_laplacian_spectra_01neg`](@ref) helper, which dispatches to separate methods for
+different categories of Laplacians. The input matrix is first classified and cast to a
+concrete subtype of [`_TypedLaplacian`](@ref), allowing said helper to apply specialized
+algorithms relying on the different `{-1,0,1}`-spectral properties of different types of
+graphs. See the [`_TypedLaplacian`](@ref) documentation for more details on the different
+classifications of Laplacians and the [`_typed_laplacian_spectra_01neg`](@ref) documentation
+for more details on the optimized algorithm used for each type.
 """
 function laplacian_spectra_01neg(L::AbstractMatrix{<:Integer})
     TL = _cast_to_typed_laplacian(L)
@@ -440,10 +600,12 @@ function _typed_laplacian_spectra_01neg(TL::_EmptyGraphLaplacian)
     L = TL.matrix
     n = size(L, 1)
 
-    #= TODO: Static analysis with JET.jl reads this as either a `Matrix` or a `Vector{Any}`,
-    generating a warning given the latter possibility. Will JET complain about a potential
-    `MethodError` if we type this as `::Matrix` (in which case we'll need an `@assert`)? =#
+    #= JET.jl cannot infer whether `kernel_eigvecs_01neg` is a `Matrix{Int}` or a
+    `Vector{Any}`, so we explicitly assert its type here for compiler inference during
+    static analysis. =#
     kernel_eigvecs_01neg = hcat(_pot_kernel_eigvecs_01neg(n)...)
+    @assert kernel_eigvecs_01neg isa Matrix{Int}
+
     eigvecs_01neg = Dict(0 => kernel_eigvecs_01neg)
     indices_1neg = _find_indices_1neg(eigvecs_01neg)
     pot_kernel_basis_1neg = _extract_independent_cols(kernel_eigvecs_01neg)
@@ -485,8 +647,14 @@ function _typed_laplacian_spectra_01neg(TL::_CompleteGraphLaplacian)
     eigval_nonzero = n * TL.weight
 
     kernel_eigvecs_01neg = ones(Int, n, 1) # The all-ones vector spans the kernel
-    # The non-kernel eigenspace necessarily contains all vectors orthogonal to the kernel
+
+    #= The non-kernel eigenspace necessarily contains all vectors orthogonal to the kernel,
+    so we do not need to filter through the output of the generator. =#
+    #= Additionally, JET.jl cannot infer whether `nonkernel_eigvecs_01neg` is a
+    `Matrix{Int}` or a `Vector{Any}`, so we explicitly assert its type here for compiler
+    inference during static analysis. =#
     nonkernel_eigvecs_01neg = hcat(_pot_nonkernel_eigvecs_01neg(n)...)
+    @assert nonkernel_eigvecs_01neg isa Matrix{Int}
 
     # All the {-1,0,1}-eigenvectors corresponding to each eigenvalue, as columns of a matrix
     eigvecs_01neg = Dict(

--- a/src/s_bandwidth.jl
+++ b/src/s_bandwidth.jl
@@ -6,6 +6,10 @@
 
 # TODO: Implement
 
+#= TODO: Implement sorting (see `check_spectrum_integrality`). First check if the eigenstuff
+is already sorted, then raise an EfficiencyWarning (like DBSCAN in scikit-learn) if not and
+sort. This will be slower if the input is not sorted but faster if it is (as we expect). =#
+
 """
     s_bandwidth()
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,7 +29,7 @@ struct NotImplementedError <: Exception
 end
 
 function Base.showerror(io::IO, e::NotImplementedError)
-    print(
+    return print(
         io,
         """NotImplementedError with `$(e.concretetype)`:
         The function `$(e.f)` is not yet implemented for this subtype of `$(e.abstracttype)`.""",
@@ -161,16 +161,9 @@ end
 
 Return a reasonable relative tolerance for computing matrix rank via SVD or QRD.
 
-If using SVD to compute rank with singular values Ω, then the intended use case is to
-numerically estimate the rank `r` of `A` by `r = count(Ω .> maximum(Ω) * _rank_rtol(A))`.
-Similarly, if using QRD to compute rank with scaling coefficients Δ (the diagonal entries of
-the `R` matrix in `A = QR`), then the user should numerically estimate the rank by `r =
-count(Δ .> maximum(Δ) * _rank_rtol(A))`.
-
-Since the machine epsilon is only defined for floating-point types, we call `eps()`
-(defaulting to `Float64`) instead of `eps(eltype(A))` when computing the tolerance. If the
-elements of `A` are floats, on the other hand, then this function dispatches to a separate
-method that uses the element type's machine epsilon.
+The output is intended to be passed as a keyword argument to `LinearAlgebra.rank`.
+`LinearAlgebra.eigtype` is used to determine the appropriate machine epsilon for the element
+type of `A` when `eltype(A)` is not an `AbstractFloat`.
 
 # Arguments
 - `A::AbstractMatrix{<:Real}`: the matrix for which to compute a tolerance.
@@ -180,52 +173,42 @@ method that uses the element type's machine epsilon.
     This scales proportionally to the maximum dimension of `A`.
 
 # Notes
-This is very much an *ad hoc* function applied specifically for numerical stability within
-this package and is never meant to be used as part of the public API. The
-`sqrt(maximum(size(A)) * eps())` formula is inspired by NumPy's default relative tolerance
-of `maximum(size(A)) * eps()` in the `numpy.linalg.matrix_rank` function [numpy25](@cite),
-with a square root taken for additional robustness. (In particular, the short, fat matrices
-holding all `{-1,0,1}`-eigenvectors of a Laplacian matrix are often ill-conditioned, hence
-the need for this higher tolerance.)
-
-In the case of using SVD to compute matrix rank, the decision to default to the `Float64`
-machine epsilon is motivated by how `LinearAlgebra.rank` handles non-floating-point
-matrices, as LAPACK automatically converts to `Float64` under the hood. In the case of QRD,
-our *ad hoc* use of this function in [`_extract_independent_cols`](@ref) takes in
-floating-point matrices anyway, so this particular method is no longer relevant.
+`LinearAlgebra.rank`'s default `rtol` of `min(m,n) * ϵ` for computing the rank of an `m × n`
+matrix may result in overestimating rank when `|m - n| ≫ 0`, since condition number (which
+determines how numerically stable SVD and QRD are) grows with both dimensions
+[CD05; p. 603](@cite). Given that we often deal with short-and-fat matrices in this package
+(particularly when processing all `{-1,0,1}`-eigenvectors of a Laplacian matrix), we turn
+instead to the same relative tolerance used by NumPy's and MATLAB's rank
+functions—`max(m,n) * ϵ` [Num25, MAT25](@cite). (Indeed, this is a widely adopted standard
+across the field of numerical analysis [PTVF07; p. 795](@cite).)
 """
-function _rank_rtol(A::AbstractMatrix{<:Real})
-    return sqrt(maximum(size(A)) * eps())
+function _rank_rtol(A::AbstractMatrix{T}) where {T}
+    return maximum(size(A)) * eps(LinearAlgebra.eigtype(T))
 end
 
-"""
-    function _rank_rtol(A::AbstractMatrix{<:AbstractFloat})
+#= In Julia 1.12+, `LinearAlgebra.rank` dispatches to a method that re-uses an existing QR
+decomposition. For compatibility with v1.10–1.11, we manually define it ourselves here. =#
+@static if VERSION < v"1.12"
+    #! format: off
+    function rank(A::QRPivoted; atol::Real=0, rtol::Real=min(size(A)...) * eps(real(float(eltype(A)))) * iszero(atol))
+        m = min(size(A)...)
+        m == 0 && return 0
+        tol = max(atol, rtol*abs(A.factors[1,1]))
+        return something(findfirst(i -> abs(A.factors[i,i]) <= tol, 1:m), m+1) - 1
+    end
+    #! format: on
 
-Return a reasonable relative tolerance for computing matrix rank via SVD or QRD.
+    @doc """
+        rank(A::QRPivoted{<:Any, T}; atol::Real=0, rtol::Real=min(n,m)*ϵ) where {T}
 
-If using SVD to compute rank with singular values `Ω`, then the intended use case is to
-numerically estimate the rank `r` of `A` by `r = count(Ω .> maximum(Ω) * _rank_rtol(A))`.
-Similarly, if using QRD to compute rank with scaling coefficients `Δ` (the diagonal entries
-of the `R` matrix in `A = QR`), then the user should numerically estimate the rank by `r =
-count(Δ .> maximum(Δ) * _rank_rtol(A))`.
+    Compute the numerical rank of the QR factorization `A` by counting how many diagonal entries of
+    `A.factors` are greater than `max(atol, rtol*Δ₁)` where `Δ₁` is the largest calculated such entry.
+    This is equivalent to the default [`rank(::AbstractMatrix)`](@ref) method except that it re-uses an existing QR factorization.
+    `atol` and `rtol` are the absolute and relative tolerances, respectively.
+    The default relative tolerance is `n*ϵ`, where `n` is the size of the smallest dimension of `A`
+    and `ϵ` is the `eps` of the element type of `A`.
 
-# Arguments
-- `A::AbstractMatrix{T<:AbstractFloat}`: the matrix for which to compute a tolerance.
-
-# Returns
-- `tol::Float64`: a reasonable relative tolerance for computing matrix rank via SVD or QRD.
-    This scales proportionally to the maximum dimension of `A` and the machine epsilon of
-    the element type `T`.
-
-# Notes
-This is very much an *ad hoc* function applied specifically for numerical stability within
-this package and is never meant to be used as part of the public API. The
-`sqrt(maximum(size(A)) * eps())` formula is inspired by NumPy's default relative tolerance
-of `maximum(size(A)) * eps()` in the `numpy.linalg.matrix_rank` function [numpy25](@cite),
-with a square root taken for additional robustness. (In particular, the short, fat matrices
-holding all `{-1,0,1}`-eigenvectors of a Laplacian matrix are often ill-conditioned, hence
-the need for this higher tolerance.)
-"""
-function _rank_rtol(A::AbstractMatrix{T}) where {T<:AbstractFloat}
-    return sqrt(maximum(size(A)) * Float64(eps(T)))
+    !!! compat "Julia 1.12"
+        The `rank(::QRPivoted)` method requires at least Julia 1.12.
+    """ -> LinearAlgebra.rank
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -190,7 +190,7 @@ end
 decomposition. For compatibility with v1.10–1.11, we manually define it ourselves here. =#
 @static if VERSION < v"1.12"
     #! format: off
-    function LinearAlgebra.rank(A::QRPivoted; atol::Real=0, rtol::Real=min(size(A)...) * eps(real(float(eltype(A)))) * iszero(atol))
+    function rank(A::QRPivoted; atol::Real=0, rtol::Real=min(size(A)...) * eps(real(float(eltype(A)))) * iszero(atol))
         m = min(size(A)...)
         m == 0 && return 0
         tol = max(atol, rtol*abs(A.factors[1,1]))
@@ -203,12 +203,18 @@ decomposition. For compatibility with v1.10–1.11, we manually define it oursel
 
     Compute the numerical rank of the QR factorization `A` by counting how many diagonal entries of
     `A.factors` are greater than `max(atol, rtol*Δ₁)` where `Δ₁` is the largest calculated such entry.
-    This is equivalent to the default `rank(::AbstractMatrix)` method except that it re-uses an existing QR factorization.
+    This is similar to the `LinearAlgebra.rank(::AbstractMatrix)` method insofar as it counts the number of
+    (numerically) nonzero coefficients from a matrix factorization, although the default method uses an
+    SVD instead of a QR factorization. Like `LinearAlgebra.rank(::SVD)`, this method also re-uses an existing
+    matrix factorization.
+
+    Computing rank via QR factorization should almost always produce the same results as via SVD,
+    although this method may be more prone to overestimating the rank in pathological cases where the
+    matrix is ill-conditioned. It is also worth noting that it is generally faster to compute a QR
+    factorization than an SVD, so this method may be preferred when performance is a concern.
+
     `atol` and `rtol` are the absolute and relative tolerances, respectively.
     The default relative tolerance is `n*ϵ`, where `n` is the size of the smallest dimension of `A`
     and `ϵ` is the `eps` of the element type of `A`.
-
-    !!! compat "Julia 1.12"
-        The `rank(::QRPivoted)` method requires at least Julia 1.12.
-    """ -> LinearAlgebra.rank
+    """ -> rank
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -190,7 +190,7 @@ end
 decomposition. For compatibility with v1.10–1.11, we manually define it ourselves here. =#
 @static if VERSION < v"1.12"
     #! format: off
-    function rank(A::QRPivoted; atol::Real=0, rtol::Real=min(size(A)...) * eps(real(float(eltype(A)))) * iszero(atol))
+    function LinearAlgebra.rank(A::QRPivoted; atol::Real=0, rtol::Real=min(size(A)...) * eps(real(float(eltype(A)))) * iszero(atol))
         m = min(size(A)...)
         m == 0 && return 0
         tol = max(atol, rtol*abs(A.factors[1,1]))
@@ -203,7 +203,7 @@ decomposition. For compatibility with v1.10–1.11, we manually define it oursel
 
     Compute the numerical rank of the QR factorization `A` by counting how many diagonal entries of
     `A.factors` are greater than `max(atol, rtol*Δ₁)` where `Δ₁` is the largest calculated such entry.
-    This is equivalent to the default [`rank(::AbstractMatrix)`](@ref) method except that it re-uses an existing QR factorization.
+    This is equivalent to the default `rank(::AbstractMatrix)` method except that it re-uses an existing QR factorization.
     `atol` and `rtol` are the absolute and relative tolerances, respectively.
     The default relative tolerance is `n*ϵ`, where `n` is the size of the smallest dimension of `A`
     and `ϵ` is the `eps` of the element type of `A`.

--- a/test/static_analysis/jet.jl
+++ b/test/static_analysis/jet.jl
@@ -17,7 +17,7 @@ using SDiagonalizability
     @show length(jet_reports)
     @show rep
 
-    @test length(jet_reports) < 30
+    @test length(jet_reports) < 25
     @test_broken length(jet_reports) == 0
 end
 


### PR DESCRIPTION
This PR continues to add/update docstrings and inline comments throughout the codebase. Recall that the current status of our project so far is that everything is working except for the `src/s_bandwidth.jl` file tying together the whole codebase into our overarching algorithm. (Of course, unit tests still need to be implemented.)

With this in mind, we note that this PR completes docstrings (complete with doctests + examples where appopriate) and inline comments for all top-level objects in `src/` (and `src/factories/`) except for in `src/laplacian_spectra.jl` and in `src/basis_search.jl`, both of which are around half done. We choose to merge already to minimize merge conflicts with concurrent work.

We also make a minor change to the README and the documentation homepage, updating the installation requirements (clarifying that a Julia runtime with version 1.10+ is needed) and lower the threshold for JET static analysis reports to `<25`. Some further design choices are refined as well.