### PR TITLE
Remove logo from Documenter

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,3 @@
-```@raw html
-<img src="https://github.com/GraphQuantum/SDiagonalizability.jl/raw/main/docs/src/assets/logo.jpg" alt="GraphQuantum logo by Madiha Waqar" height="175"/>
-<sup><sub><em>GraphQuantum</em> logo by <a href="https://github.com/madihaahmed1">Madiha Waqar</a></sub></sup>
-```
-
 ```@meta
 CurrentModule = SDiagonalizability
 ```


### PR DESCRIPTION
The logo is already in the Documenter page's sidebar anyway, so due to formatting issues, we remove it from the main page itself.