### PR TITLE
WIP: Working on Laplacian S-spectra logic

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,3 +1,14 @@
+@article{BG65,
+  author = {Businger, Peter and Golub, Gene H.},
+  journal = {*Numerische Mathematik*},
+  number = {3},
+  title = {Linear Least Squares Solutions by Householder Transformations},
+  volume = {7},
+  year = {1965},
+  pages = {269--76},
+  url = {https://doi.org/10.1007/BF01436084},
+}
+
 @article{CD05,
   author = {Chen, Zizhong and Dongarra, Jackie},
   journal = {*SIAM Journal on Matrix Analysis and Applications*},
@@ -17,6 +28,25 @@
   year = {2025},
   url = {https://oeis.org/A097861},
   note = {Accessed: 2025-05-22},
+}
+
+@misc{Fox09,
+  author = {Fox, Jacob},
+  institution = {Massachusetts Institute of Technology},
+  howpublished = {Lecture notes, MAT 307: Combinatorics},
+  title = {Lecture 19: The Petersen graph and Moore graphs},
+  year = {2009},
+  url = {https://math.mit.edu/~fox/MAT307.html},
+  note = {Accessed: 2025-07-25},
+}
+
+@misc{Joy15,
+  author = {Joyce, David},
+  institution = {Clark University},
+  howpublished = {Lecture notes, Math 130: Linear Algebra},
+  title = {Rotations and complex eigenvalues},
+  year = {2015},
+  url = {http://aleph0.clarku.edu/~ma130/complexeigen.pdf},
 }
 
 @article{JP25,

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -15,15 +15,18 @@ module SDiagonalizability
 
 using Combinatorics
 using DataStructures
-# using ElasticArrays
+using ElasticArrays
 using Graphs
 using LinearAlgebra
 
 include("utils.jl")
 include("types.jl")
 
+include("factories/laplacian_factory.jl")
+# include("factories/orthogonality_factory.jl")
+
 include("eigenvector_generation.jl")
-# include("laplacian_spectra.jl")
+include("laplacian_s_spectra.jl")
 # include("basis_search.jl")
 
 # include("core.jl")

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -5,14 +5,23 @@
 # distributed except according to those terms.
 
 """
-    pot_kernel_s_eigvecs(S, n)
+    pot_kernel_s_eigvecs(n, S) -> Iterators.Flatten{<:Base.Generator}
 
+[TODO: Write here]
+
+# Arguments
+[TODO: Write here]
+
+# Returns
 [TODO: Write here]
 
 # Throws
 - `DomainError`: if `n` is negative.
+
+# Examples
+[TODO: Write here]
 """
-function pot_kernel_s_eigvecs(S::Tuple, n::Integer)
+function pot_kernel_s_eigvecs(n::Integer, S::Tuple)
     if n < 0
         throw(DomainError(n, "Laplacian order must be non-negative"))
     end
@@ -29,14 +38,23 @@ function pot_kernel_s_eigvecs(S::Tuple, n::Integer)
 end
 
 """
-    pot_nonkernel_s_eigvecs(S, n)
+    pot_nonkernel_s_eigvecs(n, S) -> Iterators.Flatten{<:Base.Generator}
 
+[TODO: Write here]
+
+# Arguments
+[TODO: Write here]
+
+# Returns
 [TODO: Write here]
 
 # Throws
 - `DomainError`: if `n` is negative.
+
+# Examples
+[TODO: Write here]
 """
-function pot_nonkernel_s_eigvecs(S::Tuple, n::Integer)
+function pot_nonkernel_s_eigvecs(n::Integer, S::Tuple)
     if n < 0
         throw(DomainError(n, "Laplacian order must be non-negative"))
     end
@@ -53,12 +71,12 @@ function pot_nonkernel_s_eigvecs(S::Tuple, n::Integer)
 end
 
 """
-    _pot_kernel_01neg_eigvecs(n)
+    _pot_kernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily generate all potential kernel `{-1,0,1}`-eigenvectors of an order `n` Laplacian.
+Lazily compute all potential kernel ``{-1,0,1}``-eigenvectors of an ``n×n`` Laplacian.
 
-Each vector is normalized so that its first nonzero entry is `1`, enforcing pairwise linear
-independence between all generated vectors.
+Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
+linear independence between all generated vectors.
 
 # Arguments
 - `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
@@ -66,11 +84,11 @@ independence between all generated vectors.
 
 # Returns
 - `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all `{-1,0,1}`-vectors in `ℝⁿ`, unique up to span.
+    all ``{-1,0,1}``-vectors in ``ℝⁿ``, unique up to span.
 
 # Examples
-Generate all potential kernel eigenvectors for an order `3` Laplacian matrix:
-```jldoctest; setup = :(using SDiagonalizability)
+Generate all potential kernel eigenvectors for an order ``3`` Laplacian matrix:
+```jldoctest
 julia> hcat(SDiagonalizability._pot_kernel_01neg_eigvecs(3)...)
 3×13 Matrix{Int64}:
   1   1   1   1  1  1   1  1  1   0  0  0  0
@@ -79,8 +97,8 @@ julia> hcat(SDiagonalizability._pot_kernel_01neg_eigvecs(3)...)
 ```
 
 # Notes
-The number of potential kernel eigenvectors (unique up to span) for an order `n` Laplacian
-matrix is given by `(3ⁿ - 1) / 2`. See also the relevant OEIS sequence [Slo25](@cite).
+The number of potential kernel eigenvectors (unique up to span) for an order ``n`` Laplacian
+matrix is given by ``(3ⁿ - 1) / 2``. See also the relevant OEIS sequence [Slo25](@cite).
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
 noting that eigenvector generation is one of two major bottlenecks in the overall
@@ -121,7 +139,7 @@ end
 Base.eltype(::typeof(_pot_kernel_01neg_eigvecs(0))) = Vector{Int}
 
 """
-    _pot_kernel_1neg_eigvecs(n)
+    _pot_kernel_1neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
 [TODO: Write here. Also, comment inline]
 """
@@ -142,14 +160,14 @@ end
 Base.eltype(::typeof(_pot_kernel_1neg_eigvecs(0))) = Vector{Int}
 
 """
-    _pot_nonkernel_01neg_eigvecs(n)
+    _pot_nonkernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily generate all potential non-kernel `{-1,0,1}`-eigenvectors of an order `n` Laplacian.
+Lazily compute all potential non-kernel ``{-1,0,1}``-eigenvectors of an ``n×n`` Laplacian.
 
-Each vector is normalized so that its first nonzero entry is `1`, enforcing pairwise linear
-independence between all generated vectors. Since all Laplacian matrices have pairwise
-orthogonal eigenspaces and the all-ones vector is always in the kernel, every non-kernel
-`{-1,0,1}`-eigenvector must also have an equal number of `-1`'s and `1`'s.
+Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
+linear independence between all generated vectors. Since all Laplacian matrices have
+pairwise orthogonal eigenspaces and the all-ones vector is always in the kernel, every
+non-kernel ``{-1,0,1}``-eigenvector must also have an equal number of ``-1``'s and ``1``'s.
 
 # Arguments
 - `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
@@ -157,12 +175,12 @@ orthogonal eigenspaces and the all-ones vector is always in the kernel, every no
 
 # Returns
 - `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all `{-1,0,1}`-vectors in `ℝⁿ` orthogonal to the all-ones kernel vector, unique up to
-    span.
+    all ``{-1,0,1}``-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector, unique up
+    to span.
 
 # Examples
-Generate all potential non-kernel eigenvectors of an order `4` Laplacian matrix:
-```jldoctest; setup = :(using SDiagonalizability)
+Generate all potential non-kernel eigenvectors of an order ``4`` Laplacian matrix:
+```jldoctest
 julia> hcat(SDiagonalizability._pot_nonkernel_01neg_eigvecs(4)...)
 4×9 Matrix{Int64}:
   1   1   1   1   1   1   0   0   0
@@ -172,9 +190,9 @@ julia> hcat(SDiagonalizability._pot_nonkernel_01neg_eigvecs(4)...)
 ```
 
 # Notes
-The number of potential non-kernel eigenvectors (unique up to span) for an order `n`
+The number of potential non-kernel eigenvectors (unique up to span) for an order ``n``
 Laplacian matrix is, by non-trivial combinatorial arguments, equal to the number of humps in
-all Motzkin paths of length `n`. See also the relevant OEIS sequence [Deu25](@cite).
+all Motzkin paths of length ``n``. See also the relevant OEIS sequence [Deu25](@cite).
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
 noting that eigenvector generation is one of two major bottlenecks in the overall

--- a/src/factories/laplacian_factory.jl
+++ b/src/factories/laplacian_factory.jl
@@ -1,0 +1,176 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    ClassifiedLaplacian
+
+An abstract type representing a classified Laplacian matrix of an undirected graph.
+
+# Interface
+Concrete subtypes of `_TypedLaplacian` *must* implement the following fields:
+- `matrix::Matrix{Int}`: the Laplacian matrix of the graph.
+"""
+abstract type ClassifiedLaplacian end
+
+"""
+    NullGraphLaplacian <: ClassifiedLaplacian
+
+[TODO: Write here]
+"""
+struct NullGraphLaplacian <: ClassifiedLaplacian
+    matrix::Matrix{Int}
+end
+
+"""
+    EmptyGraphLaplacian <: ClassifiedLaplacian
+
+[TODO: Write here]
+"""
+struct EmptyGraphLaplacian <: ClassifiedLaplacian
+    matrix::Matrix{Int}
+end
+
+"""
+    CompleteGraphLaplacian <: ClassifiedLaplacian
+
+[TODO: Write here]
+"""
+struct CompleteGraphLaplacian <: ClassifiedLaplacian
+    matrix::Matrix{Int}
+    weight::Int
+end
+
+"""
+    ArbitraryGraphLaplacian <: ClassifiedLaplacian
+
+[TODO: Write here]
+"""
+struct ArbitraryGraphLaplacian <: ClassifiedLaplacian
+    matrix::Matrix{Int}
+end
+
+"""
+    classify_laplacian(L)
+
+Classify the Laplacian matrix `L` and wrap it in a [`ClassifiedLaplacian`](@ref) object.
+
+It is first verified that `L` is indeed a Laplacian matrix by
+[`_assert_matrix_is_undirected_laplacian`](@ref), which throws a `DomainError` otherwise. It
+is then classified based on any properties which may be exploited in computing data on its
+`{-1,0,1}`-spectrum.
+
+# Arguments
+- `L::AbstractMatrix{<:Integer}`: the Laplacian matrix to classify.
+
+# Returns
+- `CL::ClassifiedLaplacian`: the Laplacian wrapped in a concrete
+    [`ClassifiedLaplacian`](@ref) subtype associated with the category of the
+    graph represented by `L`. In the case of complete graphs, `CL` also contains data on the
+    (necessarily uniform) weight of each edge.
+
+# Examples
+Correctly recognizes the Laplacian matrix of the null graph:
+```jldoctest
+julia> using Graphs
+
+julia> G = Graph(0)
+{0, 0} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+0×0 SparseArrays.SparseMatrixCSC{Int64, Int64} with 0 stored entries
+
+julia> SDiagonalizability.classify_laplacian(L)
+SDiagonalizability.NullGraphLaplacian(Matrix{Int64}(undef, 0, 0))
+```
+
+Correctly recognizes the Laplacian matrix of the empty graph on ``3`` nodes:
+```jldoctest
+julia> using Graphs
+
+julia> G = Graph(3)
+{3, 0} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+3×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 0 stored entries:
+ ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅
+
+julia> SDiagonalizability.classify_laplacian(L)
+SDiagonalizability.EmptyGraphLaplacian([0 0 0; 0 0 0; 0 0 0])
+```
+
+Correctly recognizes the Laplacian matrix of the complete graph on ``4`` nodes:
+```jldoctest
+julia> using Graphs
+
+julia> G = complete_graph(4)
+{4, 6} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+4×4 SparseArrays.SparseMatrixCSC{Int64, Int64} with 16 stored entries:
+  3  -1  -1  -1
+ -1   3  -1  -1
+ -1  -1   3  -1
+ -1  -1  -1   3
+
+julia> SDiagonalizability.classify_laplacian(L)
+SDiagonalizability.CompleteGraphLaplacian([3 -1 -1 -1; -1 3 -1 -1; -1 -1 3 -1; -1 -1 -1 3], 1)
+```
+
+Correctly recognizes the Laplacian matrix of this random generic graph:
+```jldoctest
+julia> using Graphs
+
+julia> G = erdos_renyi(5, 8; seed=87)
+{5, 8} undirected simple Int64 graph
+
+julia> L = laplacian_matrix(G)
+5×5 SparseArrays.SparseMatrixCSC{Int64, Int64} with 21 stored entries:
+  3   ⋅  -1  -1  -1
+  ⋅   2  -1  -1   ⋅
+ -1  -1   4  -1  -1
+ -1  -1  -1   4  -1
+ -1   ⋅  -1  -1   3
+
+julia> SDiagonalizability.classify_laplacian(L)
+SDiagonalizability.ArbitraryGraphLaplacian([3 0 … -1 -1; 0 2 … -1 0; … ; -1 -1 … 4 -1; -1 0 … -1 3])
+```
+# Notes
+Right now, the possible types of Laplacian matrices (or, to be more precise, the graphs they
+represent) are:
+- [`NullGraphLaplacian`](@ref): the (unique) graph with no nodes.
+- [`EmptyGraphLaplacian`](@ref): any graph with no edges on ``n ≥ 1`` nodes.
+- [`CompleteGraphLaplacian`](@ref): any graph on ``n ≥ 2`` nodes where every pair of nodes is
+    connected by an edge and all edges possess the same weight.
+- [`ArbitraryGraphLaplacian`](@ref): any graph on ``n ≥ 3`` nodes with no particular
+    strcuture of relevance in the context of investigating ``{-1,0,1}``-spectra.
+"""
+function classify_laplacian(L::AbstractMatrix{<:Integer})
+    #= Verify that `L` is symmetric (thus representing an undirected graph) and has zero row
+    sums (thus being a Laplacian matrix). =#
+    _assert_matrix_is_undirected_laplacian(L)
+
+    L_copy = Matrix{Int}(L) # Avoid shared mutability and cast to `Matrix{Int}`
+    n = size(L_copy, 1)
+
+    if n == 0 # The graph has no nodes
+        CL = NullGraphLaplacian(L_copy)
+    elseif iszero(L_copy) # The graph has no edges
+        CL = EmptyGraphLaplacian(L_copy)
+    #! format: off
+    #= We have already verified symmetry, so equality of all strictly upper-triangular
+    elements is a sufficient condition for `L` to represent a complete graph. =#
+    #! format: on
+    elseif allequal(L_copy[i, j] for i in 1:(n - 1) for j in (i + 1):n)
+        weight = -L_copy[1, 2]
+        CL = CompleteGraphLaplacian(L_copy, weight)
+    else # The graph has no particular structure of interest
+        CL = ArbitraryGraphLaplacian(L_copy)
+    end
+
+    return CL
+end

--- a/src/laplacian_s_spectra.jl
+++ b/src/laplacian_s_spectra.jl
@@ -1,0 +1,320 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    laplacian_s_spectra(L, S) -> SSpectra
+
+[TODO: Write here. Also, comment inline]
+"""
+function laplacian_s_spectra(L::AbstractMatrix{<:Integer}, S::Tuple)
+    _assert_matrix_is_undirected_laplacian(L)
+
+    if S == (-1, 0, 1)
+        spec = _laplacian_01neg_spectra(L)
+    elseif S == (-1, 1)
+        spec = _laplacian_1neg_spectra(L)
+    else
+        throw(ArgumentError("Unsupported entry set S: $S"))
+    end
+
+    return spec
+end
+
+"""
+    check_spectrum_integrality(A) -> SpectrumIntegralResult
+
+Check whether the eigenvalues of `A` are integers (up to floating-point error).
+
+If the eigenvalues are indeed all integers, then an eigenvalue-multiplicity map is
+constructed as well.
+
+# Arguments
+- `A::AbstractMatrix{<:Integer}`: the matrix whose eigenvalues to check for integrality.
+
+# Returns
+- `::SpectrumIntegralResult`: a struct containing the following fields:
+    - `matrix`: the `A` matrix, copied to avoid shared mutability.
+    - `spectrum_integral`: whether the eigenvalues of `A` are integers.
+    - `multiplicities`: a map from each eigenvalue to its multiplicity, sorted first by
+        ascending multiplicity then by ascending eigenvalue. (This field is `nothing` if the
+        eigenvalues are not all integers.)
+
+# Examples
+Confirm that the rotation matrix by ``π/2`` radians counterclockwise is not spectrum
+integral (rather, it has eigenvalues ``±i`` [Joy15; p. 1](@cite)):
+```jldoctest
+julia> R = Int8.([0 -1; 1 0])
+2×2 Matrix{Int8}:
+ 0  -1
+ 1   0
+
+julia> res = SDiagonalizability.check_spectrum_integrality(R);
+
+julia> res.matrix
+2×2 Matrix{Int64}:
+ 0  -1
+ 1   0
+
+julia> res.spectrum_integral
+false
+
+julia> isnothing(res.multiplicities)
+true
+```
+
+Confirm that the adjacency matrix of the Petersen graph is spectrum integral, with correct
+eigenvalues and multiplicities of ``{3: 1, -2: 4, 1: 5}`` [Fox09; p. 2](@cite):
+```jldoctest
+julia> using Graphs
+
+julia> G = smallgraph(:petersen)
+{10, 15} undirected simple Int64 graph
+
+julia> A = adjacency_matrix(G)
+10×10 SparseArrays.SparseMatrixCSC{Int64, Int64} with 30 stored entries:
+ ⋅  1  ⋅  ⋅  1  1  ⋅  ⋅  ⋅  ⋅
+ 1  ⋅  1  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅
+ ⋅  1  ⋅  1  ⋅  ⋅  ⋅  1  ⋅  ⋅
+ ⋅  ⋅  1  ⋅  1  ⋅  ⋅  ⋅  1  ⋅
+ 1  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  1
+ 1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  1  ⋅
+ ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  1
+ ⋅  ⋅  1  ⋅  ⋅  1  ⋅  ⋅  ⋅  1
+ ⋅  ⋅  ⋅  1  ⋅  1  1  ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅  ⋅  1  ⋅  1  1  ⋅  ⋅
+
+julia> res = SDiagonalizability.check_spectrum_integrality(A);
+
+julia> res.matrix
+10×10 Matrix{Int64}:
+ 0  1  0  0  1  1  0  0  0  0
+ 1  0  1  0  0  0  1  0  0  0
+ 0  1  0  1  0  0  0  1  0  0
+ 0  0  1  0  1  0  0  0  1  0
+ 1  0  0  1  0  0  0  0  0  1
+ 1  0  0  0  0  0  0  1  1  0
+ 0  1  0  0  0  0  0  0  1  1
+ 0  0  1  0  0  1  0  0  0  1
+ 0  0  0  1  0  1  1  0  0  0
+ 0  0  0  0  1  0  1  1  0  0
+
+julia> res.spectrum_integral
+true
+
+julia> res.multiplicities
+OrderedCollections.OrderedDict{Int64, Int64} with 3 entries:
+  3  => 1
+  -2 => 4
+  1  => 5
+```
+
+# Notes
+If an undirected graph with integer edge weights is ``{-1,0,1}``-diagonalizable (or, more
+restrictively, ``{-1,1}``-diagonalizable), then its Laplacian matrix has integer eigenvalues
+[JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
+step in this package's principal *S*-bandwidth minimization algorithm.
+"""
+function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
+    A_copy = Matrix{Int}(A) # Avoid shared mutability and cast to `Matrix{Int}`
+
+    eigvals_float = eigvals(A_copy)
+    eigvals_int = Int.(round.(real.(eigvals_float)))
+    spectrum_integral = isapprox(eigvals_float, eigvals_int)
+
+    # Sort first by ascending multiplicity then by ascending eigenvalue
+    if spectrum_integral
+        multiplicities = OrderedDict(sort!(collect(counter(eigvals_int)); by=reverse))
+    else
+        multiplicities = nothing
+    end
+
+    return SpectrumIntegralResult(A_copy, spectrum_integral, multiplicities)
+end
+
+"""
+    _laplacian_01neg_spectra(L) -> SSpectra
+
+[TODO: Write here]
+"""
+function _laplacian_01neg_spectra(L::AbstractMatrix{<:Integer})
+    return _classified_laplacian_01neg_spectra(classify_laplacian(L))
+end
+
+"""
+    _laplacian_1neg_spectra(L) -> SSpectra
+    _laplacian_1neg_spectra(spec) -> SSpectra
+
+[TODO: Write here]
+"""
+function _laplacian_1neg_spectra(L::AbstractMatrix{<:Integer})
+    return _classified_laplacian_1neg_spectra(classify_laplacian(L))
+end
+
+function _laplacian_1neg_spectra(spec::SSpectra)
+    if spec.S != (-1, 0, 1)
+        throw(
+            ArgumentError(
+                "Expected `{-1,0,1}`-spectra` to compute `{-1,1}`-spectra, got $(spec.S)-spectra",
+            ),
+        )
+    end
+
+    # TODO: Write here. Remember to copy to avoid shared mutability. Fold
+    # `_find_indices_1neg` logic from old code into this function.
+    return nothing
+end
+
+"""
+    _classified_laplacian_01neg_spectra(CL) -> SSpectra
+
+[TODO: Write here. Also, comment inline]
+"""
+function _classified_laplacian_01neg_spectra(CL::ClassifiedLaplacian)
+    throw(
+        NotImplementedError(
+            _classified_laplacian_01neg_spectra, typeof(CL), ClassifiedLaplacian
+        ),
+    )
+end
+
+function _classified_laplacian_01neg_spectra(CL::NullGraphLaplacian)
+    return SSpectra(
+        CL.matrix,
+        (-1, 0, 1),
+        OrderedDict{Int,Int}(),
+        OrderedDict{Int,Vector{Int}}(),
+        OrderedDict{Int,Vector{Int}}(),
+        true,
+    )
+end
+
+function _classified_laplacian_01neg_spectra(CL::EmptyGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+function _classified_laplacian_01neg_spectra(CL::CompleteGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+function _classified_laplacian_01neg_spectra(CL::ArbitraryGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+"""
+    _classified_laplacian_1neg_spectra(CL) -> SSpectra
+
+[TODO: Write here. Also, comment inline]
+"""
+function _classified_laplacian_1neg_spectra(CL::ClassifiedLaplacian)
+    throw(
+        NotImplementedError(
+            _classified_laplacian_1neg_spectra, typeof(CL), ClassifiedLaplacian
+        ),
+    )
+end
+
+function _classified_laplacian_1neg_spectra(CL::NullGraphLaplacian)
+    return SSpectra(
+        CL.matrix,
+        (-1, 1),
+        OrderedDict{Int,Int}(),
+        OrderedDict{Int,Vector{Int}}(),
+        OrderedDict{Int,Vector{Int}}(),
+        true,
+    )
+end
+
+function _classified_laplacian_1neg_spectra(CL::EmptyGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+function _classified_laplacian_1neg_spectra(CL::CompleteGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+function _classified_laplacian_1neg_spectra(CL::ArbitraryGraphLaplacian)
+    # TODO: Write here
+    return nothing
+end
+
+"""
+    _extract_independent_cols(A) -> Matrix{Int}
+
+Return a (not necessarily unique) independent spanning subset of the columns of `A`.
+
+Computing a rank-revealing (pivoted) QR decomposition of `A`, the scaling coefficients from
+the orthogonalization process are used to determine the rank (rather than recompute it with
+an SVD), while the pivots are used to extract a spanning set of independent columns.
+
+The rank-revealing Businger–Golub QR algorithm is used for the pivoting strategy, appending
+the "most independent" column with respect to the current set of pivots at each step via
+Householder transformations [BG65; pp. 269--70](@cite).
+
+# Arguments
+- `A::AbstractMatrix{T<:Integer}`: the matrix whose independent columns to extract.
+
+# Returns
+- `::Matrix{Int}`: a spanning set of independent columns of `A`.
+
+# Examples
+Observe how columns with greater Euclidean norms are given priority in the pivot ordering:
+```jldoctest
+julia> A = [3  0  0  0  2  1   5   0
+            0  3  0  0  2  1  -5   0
+            0  0  3  0  2  1   5   4
+            0  0  0  3  2  1   0  -4
+            0  0  0  0  0  0   0   0]
+5×8 Matrix{Int64}:
+ 3  0  0  0  2  1   5   0
+ 0  3  0  0  2  1  -5   0
+ 0  0  3  0  2  1   5   4
+ 0  0  0  3  2  1   0  -4
+ 0  0  0  0  0  0   0   0
+
+julia> SDiagonalizability._extract_independent_cols(A)
+5×4 Matrix{Int64}:
+  5   0  2  3
+ -5   0  2  0
+  5   4  2  0
+  0  -4  2  0
+  0   0  0  0
+```
+
+# Notes
+Since we already need a pivoted QR decomposition to identify independent columns of `A` (or,
+rather, to order the columns in such a way that the first `rank(A)` ones are guaranteed to
+be independent), it makes sense to use data from the resulting factorization object to
+compute the rank of `A` rather than compute a separate SVD. We thus count the nonzero scaling
+coefficients—that is, the diagonal entries of the `R` matrix in `A = QR`—to determine the
+rank, similarly to how we count the nonzero singular values in an SVD.
+
+It is worth noting that we manually specify a higher relative tolerance for this rank
+computation. Further discussion can be found in the [`_rank_rtol`](@ref) documentation, but
+in short, a critical part of the formula for `LinearAlgebra.rank`'s default `rtol`
+uses the minimum dimension of the input matrix. This may result in rank overestimation for
+tall-and-skinny and short-and-fat matrices (precisely the type we expect to encounter when
+dealing with all ``{-1,0,1}``-eigenvectors of a Laplacian matrix, which is the intended use
+case of this helper function in this package). Our replacement tolerance, on the other hand,
+is a widely accepted standard in numerical analysis which uses the maximum dimension instead
+[PTVF07; p. 795](@cite).
+"""
+function _extract_independent_cols(A::AbstractMatrix{<:Integer})
+    F = qr(A, ColumnNorm())
+    rtol = _rank_rtol(A) # Use a higher tolerance (NumPy's/MATLAB's) than Julia's default
+
+    #= In Julia 1.12+, `LinearAlgebra.rank` dispatches to a method that re-uses an existing
+    QR decomposition. For compatibility with v1.10–1.11, we manually define it ourselves in
+    `src/utils.jl`. =#
+    r = rank(F; rtol=rtol)
+    pivots = F.p[1:r] # The first `rank(A)` pivots correspond to independent columns of `A`
+
+    return Matrix{Int}(A[:, pivots]) # Copy to avoid shared mutability
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -54,6 +54,21 @@ struct SBandRecognitionResult{
     k::Int
     has_band_k_diag::Bool
 end
+
+"""
+    SSpectra{A,B,C,D}
+
+[TODO: Write here]
+"""
+struct SSpectra{A<:Tuple,B<:Union{Nothing,OrderedDict{Int}},C<:B,D<:B}
+    matrix::AbstractMatrix{<:Integer}
+    S::A
+    multiplicities::B
+    s_eigenspaces::C
+    s_eigenbases::D
+    s_diagonalizable::Bool
+end
+
 """
     struct SpectrumIntegralResult
 
@@ -71,8 +86,8 @@ eigenvalues are indeed all integers. (Otherwise, the associated field is simply 
     non-integer eigenvalues to data.)
 
 # Notes
-If an undirected graph with integer edge weights is `{-1,0,1}`-diagonalizable (or, more
-restrictively, `{-1,1}`-diagonalizable), then its Laplacian matrix has integer eigenvalues
+If an undirected graph with integer edge weights is ``{-1,0,1}``-diagonalizable (or, more
+restrictively, ``{-1,1}``-diagonalizable), then its Laplacian matrix has integer eigenvalues
 [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
 step in this package's principal *S*-bandwidth minimization algorithm.
 """
@@ -80,20 +95,6 @@ struct SpectrumIntegralResult{T<:Union{Nothing,OrderedDict{Int,Int}}}
     matrix::AbstractMatrix{<:Integer}
     spectrum_integral::Bool
     multiplicities::T
-end
-
-"""
-    _SSpectra{A,B,C,D}
-
-[TODO: Write here]
-"""
-struct _SSpectra{A<:Tuple,B<:Union{Nothing,OrderedDict{Int}},C<:B,D<:B}
-    matrix::AbstractMatrix{<:Integer}
-    S::A
-    multiplicities::B
-    s_eigenspaces::C
-    s_eigenbases::D
-    s_diagonalizable::Bool
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    _assert_matrix_is_undirected_laplacian(L)
+    _assert_matrix_is_undirected_laplacian(L) -> Nothing
 
 Validate that `L` is the Laplacian matrix of an undirected, possibly weighted graph.
 
@@ -19,7 +19,7 @@ Validate that `L` is the Laplacian matrix of an undirected, possibly weighted gr
 - `DomainError`: if `L` is not symmetric or has nonzero row sums.
 
 # Examples
-The Laplacian matrix of the (undirected) star graph on `5` vertices passes the check:
+The Laplacian matrix of the (undirected) star graph on ``5`` vertices passes the check:
 ```jldoctest
 julia> L = [ 4  -1  -1  -1  -1;
             -1   1   0   0   0;
@@ -37,7 +37,7 @@ julia> isnothing(SDiagonalizability._assert_matrix_is_undirected_laplacian(L))
 true
 ```
 
-The adjacency matrix of the (undirected) cycle graph on `4` vertices is symmetric but has
+The adjacency matrix of the (undirected) cycle graph on ``4`` vertices is symmetric but has
 nonzero row sums, so it fails the check:
 ```jldoctest
 julia> A = [0  1  0  1;
@@ -90,16 +90,16 @@ Matrix is not symmetric; cannot be an (undirected) Laplacian
 
 # Notes
 If edges are to be bidirectional, then `L` must be symmetric. `L` must also have zero row
-sums, since the `(i, i)`-th entry is the weighted degree of node `i` (the sum of all
-incident edges' weights) and the `(i, j)`-th entry for `i ≠ j` is the negation of the weight
-of edge `(i, j)` (or simply `0`, if no such edge exists).
+sums, since the ``(i, i)``-th entry is the weighted degree of node ``i`` (the sum of all
+incident edges' weights) and the ``(i, j)``-th entry for ``i ≠ j`` is the negation of the
+weight of edge ``(i, j)`` (or simply ``0``, if no such edge exists).
 
 Given the highly optimized, lazy, zero-allocation implementation of
-`LinearAlgebra.issymmetric`, the symmetry check is performed first. (Both steps are `O(n²)`
-in the worst case, but testing for symmetry is far more performant in practice.) This also
-allows us to (also lazily) check for nonzero column sums rather than nonzero row sums (since
-these are equivalent for symmetric matrices) in the second step, taking advantage of Julia's
-column-major storage model.
+`LinearAlgebra.issymmetric`, the symmetry check is performed first. (Both steps are
+``O(n²)`` in the worst case, but testing for symmetry is far more performant in practice.)
+This also allows us to (also lazily) check for nonzero column sums rather than nonzero row
+sums (since these are equivalent for symmetric matrices) in the second step, taking
+advantage of Julia's column-major storage model.
 
 At first blush, it may seem as though the choice of `DomainError` over something like
 `ArgumentError` (or even simply the return of a boolean) constitutes poor design. However,
@@ -127,7 +127,7 @@ function _assert_matrix_is_undirected_laplacian(L::AbstractMatrix{<:Integer})
 end
 
 """
-    function _rank_rtol(A::AbstractMatrix{<:Real})
+    function _rank_rtol(A::AbstractMatrix{<:Real}) -> Float64
 
 Return a reasonable relative tolerance for computing matrix rank via SVD or QRD.
 
@@ -143,11 +143,11 @@ type of `A` when `eltype(A)` is not an `AbstractFloat`.
     This scales proportionally to the maximum dimension of `A`.
 
 # Notes
-`LinearAlgebra.rank`'s default `rtol` of `min(m,n) * ϵ` for computing the rank of an `m × n`
-matrix may result in overestimating rank when `|m - n| ≫ 0`, since condition number (which
-determines how numerically stable SVD and QRD are) grows with both dimensions
+`LinearAlgebra.rank`'s default `rtol` of `min(m,n) * ϵ` for computing the rank of an
+``m×n`` matrix may result in overestimating rank when ``|m - n| ≫ 0``, since condition
+number (which determines how numerically stable SVD and QRD are) grows with both dimensions
 [CD05; p. 603](@cite). Given that we often deal with short-and-fat matrices in this package
-(particularly when processing all `{-1,0,1}`-eigenvectors of a Laplacian matrix), we turn
+(particularly when processing all ``{-1,0,1}``-eigenvectors of a Laplacian matrix), we turn
 instead to the same relative tolerance used by NumPy's and MATLAB's rank
 functions—`max(m,n) * ϵ` [Num25, MAT25](@cite). (Indeed, this is a widely adopted standard
 across the field of numerical analysis [PTVF07; p. 795](@cite).)
@@ -186,5 +186,10 @@ decomposition. For compatibility with v1.10–1.11, we manually define it oursel
     `atol` and `rtol` are the absolute and relative tolerances, respectively.
     The default relative tolerance is `n*ϵ`, where `n` is the size of the smallest dimension of `A`
     and `ϵ` is the `eps` of the element type of `A`.
+
+    !!! note
+        When accessed directly via `LinearAlgebra`, the `rank(::QRPivoted)` method requires at least
+        Julia 1.12, so `SDiagonalizability` defines this method manually for compatibility with
+        v1.10–1.11.
     """ -> rank
 end


### PR DESCRIPTION
Currently working on source code for the Laplacian S-spectra computations. All 'skeleton' methods are added, but the actual source code + docs is not yet complete.
    
Some more notes: changed some single backticks (code blocks) to double (math expressions), added a compat note for the manual `LinearAlgebra.rank` method with `QRPivoted`, added type annotations in method docstrings.