### PR TITLE
Fix curly bracket rendering

### DIFF
--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -73,7 +73,7 @@ end
 """
     _pot_kernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily compute all potential kernel ``{-1,0,1}``-eigenvectors of an ``n×n`` Laplacian.
+Lazily compute all potential kernel ``\\{-1, 0 ,1\\}``-eigenvectors of an ``n×n`` Laplacian.
 
 Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
 linear independence between all generated vectors.
@@ -84,7 +84,7 @@ linear independence between all generated vectors.
 
 # Returns
 - `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all ``{-1,0,1}``-vectors in ``ℝⁿ``, unique up to span.
+    all ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ``, unique up to span.
 
 # Examples
 Generate all potential kernel eigenvectors for an order ``3`` Laplacian matrix:
@@ -121,7 +121,7 @@ function _pot_kernel_01neg_eigvecs(n::Integer)
             body,
         ) # Append the permuted entries to the leading [0, ..., 0, 1] vector
         for k in 1:n # Iterate over possible indices of first nonzero entry
-        # Iterate over permutations taken from the `r`-th Cartesian power of {-1,0,1}
+        # Iterate over permutations taken from the `r`-th Cartesian power of {-1, 0, 1}
         for body in multiset_permutations(
             let r = n - k
                 entries = Vector{Int}(undef, 3r)
@@ -162,12 +162,13 @@ Base.eltype(::typeof(_pot_kernel_1neg_eigvecs(0))) = Vector{Int}
 """
     _pot_nonkernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily compute all potential non-kernel ``{-1,0,1}``-eigenvectors of an ``n×n`` Laplacian.
+Lazily compute all potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors of an ``n×n`` Laplacian.
 
 Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
 linear independence between all generated vectors. Since all Laplacian matrices have
 pairwise orthogonal eigenspaces and the all-ones vector is always in the kernel, every
-non-kernel ``{-1,0,1}``-eigenvector must also have an equal number of ``-1``'s and ``1``'s.
+non-kernel ``\\{-1, 0, 1\\}``-eigenvector must also have an equal number of ``-1``'s and
+``1``'s.
 
 # Arguments
 - `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
@@ -175,8 +176,8 @@ non-kernel ``{-1,0,1}``-eigenvector must also have an equal number of ``-1``'s a
 
 # Returns
 - `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all ``{-1,0,1}``-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector, unique up
-    to span.
+    all ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector,
+    unique up to span.
 
 # Examples
 Generate all potential non-kernel eigenvectors of an order ``4`` Laplacian matrix:

--- a/src/factories/laplacian_factory.jl
+++ b/src/factories/laplacian_factory.jl
@@ -60,7 +60,7 @@ Classify the Laplacian matrix `L` and wrap it in a [`ClassifiedLaplacian`](@ref)
 It is first verified that `L` is indeed a Laplacian matrix by
 [`_assert_matrix_is_undirected_laplacian`](@ref), which throws a `DomainError` otherwise. It
 is then classified based on any properties which may be exploited in computing data on its
-`{-1,0,1}`-spectrum.
+`\\{-1, 0, 1\\}`-spectrum.
 
 # Arguments
 - `L::AbstractMatrix{<:Integer}`: the Laplacian matrix to classify.
@@ -147,7 +147,7 @@ represent) are:
 - [`CompleteGraphLaplacian`](@ref): any graph on ``n ≥ 2`` nodes where every pair of nodes is
     connected by an edge and all edges possess the same weight.
 - [`ArbitraryGraphLaplacian`](@ref): any graph on ``n ≥ 3`` nodes with no particular
-    strcuture of relevance in the context of investigating ``{-1,0,1}``-spectra.
+    strcuture of relevance in the context of investigating ``\\{-1, 0, 1\\}``-spectra.
 """
 function classify_laplacian(L::AbstractMatrix{<:Integer})
     #= Verify that `L` is symmetric (thus representing an undirected graph) and has zero row

--- a/src/laplacian_s_spectra.jl
+++ b/src/laplacian_s_spectra.jl
@@ -66,7 +66,7 @@ true
 ```
 
 Confirm that the adjacency matrix of the Petersen graph is spectrum integral, with correct
-eigenvalues and multiplicities of ``{3: 1, -2: 4, 1: 5}`` [Fox09; p. 2](@cite):
+eigenvalues and multiplicities of ``\\{3: 1, -2: 4, 1: 5\\}`` [Fox09; p. 2](@cite):
 ```jldoctest
 julia> using Graphs
 
@@ -112,10 +112,10 @@ OrderedCollections.OrderedDict{Int64, Int64} with 3 entries:
 ```
 
 # Notes
-If an undirected graph with integer edge weights is ``{-1,0,1}``-diagonalizable (or, more
-restrictively, ``{-1,1}``-diagonalizable), then its Laplacian matrix has integer eigenvalues
-[JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
-step in this package's principal *S*-bandwidth minimization algorithm.
+If an undirected graph with integer edge weights is ``\\{-1, 0, 1\\}``-diagonalizable (or,
+more restrictively, ``\\{-1, 1\\}``-diagonalizable), then its Laplacian matrix has integer
+eigenvalues [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a
+useful screening step in this package's principal *S*-bandwidth minimization algorithm.
 """
 function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
     A_copy = Matrix{Int}(A) # Avoid shared mutability and cast to `Matrix{Int}`
@@ -157,7 +157,7 @@ function _laplacian_1neg_spectra(spec::SSpectra)
     if spec.S != (-1, 0, 1)
         throw(
             ArgumentError(
-                "Expected `{-1,0,1}`-spectra` to compute `{-1,1}`-spectra, got $(spec.S)-spectra",
+                "Expected `{-1, 0, 1}`-spectra` to compute `{-1, 1}`-spectra, got $(spec.S)-spectra",
             ),
         )
     end
@@ -301,10 +301,10 @@ computation. Further discussion can be found in the [`_rank_rtol`](@ref) documen
 in short, a critical part of the formula for `LinearAlgebra.rank`'s default `rtol`
 uses the minimum dimension of the input matrix. This may result in rank overestimation for
 tall-and-skinny and short-and-fat matrices (precisely the type we expect to encounter when
-dealing with all ``{-1,0,1}``-eigenvectors of a Laplacian matrix, which is the intended use
-case of this helper function in this package). Our replacement tolerance, on the other hand,
-is a widely accepted standard in numerical analysis which uses the maximum dimension instead
-[PTVF07; p. 795](@cite).
+dealing with all ``\\{-1, 0, 1\\}``-eigenvectors of a Laplacian matrix, which is the
+intended use case of this helper function in this package). Our replacement tolerance, on
+the other hand, is a widely accepted standard in numerical analysis which uses the maximum
+dimension instead [PTVF07; p. 795](@cite).
 """
 function _extract_independent_cols(A::AbstractMatrix{<:Integer})
     F = qr(A, ColumnNorm())

--- a/src/types.jl
+++ b/src/types.jl
@@ -86,10 +86,10 @@ eigenvalues are indeed all integers. (Otherwise, the associated field is simply 
     non-integer eigenvalues to data.)
 
 # Notes
-If an undirected graph with integer edge weights is ``{-1,0,1}``-diagonalizable (or, more
-restrictively, ``{-1,1}``-diagonalizable), then its Laplacian matrix has integer eigenvalues
-[JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a useful screening
-step in this package's principal *S*-bandwidth minimization algorithm.
+If an undirected graph with integer edge weights is ``\\{-1, 0, 1\\}``-diagonalizable (or,
+more restrictively, ``\\{-1, 1\\}``-diagonalizable), then its Laplacian matrix has integer
+eigenvalues [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a
+useful screening step in this package's principal *S*-bandwidth minimization algorithm.
 """
 struct SpectrumIntegralResult{T<:Union{Nothing,OrderedDict{Int,Int}}}
     matrix::AbstractMatrix{<:Integer}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -147,8 +147,8 @@ type of `A` when `eltype(A)` is not an `AbstractFloat`.
 ``m×n`` matrix may result in overestimating rank when ``|m - n| ≫ 0``, since condition
 number (which determines how numerically stable SVD and QRD are) grows with both dimensions
 [CD05; p. 603](@cite). Given that we often deal with short-and-fat matrices in this package
-(particularly when processing all ``{-1,0,1}``-eigenvectors of a Laplacian matrix), we turn
-instead to the same relative tolerance used by NumPy's and MATLAB's rank
+(particularly when processing all ``\\{-1, 0, 1\\}``-eigenvectors of a Laplacian matrix), we
+turn instead to the same relative tolerance used by NumPy's and MATLAB's rank
 functions—`max(m,n) * ϵ` [Num25, MAT25](@cite). (Indeed, this is a widely adopted standard
 across the field of numerical analysis [PTVF07; p. 795](@cite).)
 """


### PR DESCRIPTION
This PR fixes the rendering of curly brackets in the Documenter-generated docs site.

(Fixes #7.)