### PR TITLE
Create orthogonality factory; update type docstrings

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -6,7 +6,7 @@
   volume = {7},
   year = {1965},
   pages = {269--76},
-  url = {https://doi.org/10.1007/BF01436084},
+  url = {https://doi.org/10.1007/BF01436084}
 }
 
 @article{CD05,
@@ -17,7 +17,7 @@
   volume = {27},
   year = {2005},
   pages = {603--20},
-  url = {https://doi.org/10.1137/040616413},
+  url = {https://doi.org/10.1137/040616413}
 }
 
 @misc{Deu25,
@@ -27,7 +27,7 @@
   title = {Number of humps in all Motzkin paths of length n},
   year = {2025},
   url = {https://oeis.org/A097861},
-  note = {Accessed: 2025-05-22},
+  note = {Accessed: 2025-05-22}
 }
 
 @misc{Fox09,
@@ -37,7 +37,7 @@
   title = {Lecture 19: The Petersen graph and Moore graphs},
   year = {2009},
   url = {https://math.mit.edu/~fox/MAT307.html},
-  note = {Accessed: 2025-07-25},
+  note = {Accessed: 2025-07-25}
 }
 
 @misc{Joy15,
@@ -46,7 +46,7 @@
   howpublished = {Lecture notes, Math 130: Linear Algebra},
   title = {Rotations and complex eigenvalues},
   year = {2015},
-  url = {http://aleph0.clarku.edu/~ma130/complexeigen.pdf},
+  url = {http://aleph0.clarku.edu/~ma130/complexeigen.pdf}
 }
 
 @article{JP25,
@@ -56,7 +56,18 @@
   volume = {704},
   year = {2025},
   pages = {309--39},
-  url = {https://doi.org/10.1016/j.laa.2024.10.016},
+  url = {https://doi.org/10.1016/j.laa.2024.10.016}
+}
+
+@article{Maf14,
+  author = {Mafteiu-Scai, Liviu Octavian},
+  journal = {*Annals of West University of Timisoara - Mathematics and Computer Science*},
+  number = {2},
+  title = {The Bandwidths of a Matrix. A Survey of Algorithms},
+  volume = {52},
+  year = {2014},
+  pages = {183--223},
+  url = {https://doi.org/10.2478/awutm-2014-0019}
 }
 
 @misc{MAT25,
@@ -65,7 +76,7 @@
   title = {rank},
   year = {2025},
   url = {https://www.mathworks.com/help/matlab/ref/rank.html},
-  note = {Accessed: 2025-05-29},
+  note = {Accessed: 2025-05-29}
 }
 
 @misc{Num25,
@@ -74,7 +85,7 @@
   title = {numpy.linalg.matrix_rank},
   year = {2025},
   url = {https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_rank.html},
-  note = {Accessed: 2025-05-22},
+  note = {Accessed: 2025-05-22}
 }
 
 @book{PTVF07,
@@ -85,7 +96,7 @@
   year = {2007},
   edition = {3rd},
   url = {https://dl.acm.org/doi/10.5555/1403886},
-  note = {ISBN: 978-0-521-88068-8},
+  note = {ISBN: 978-0-521-88068-8}
 }
 
 @misc{Slo25,
@@ -95,7 +106,7 @@
   title = {a(n) = (3^n - 1)/2},
   year = {2025},
   url = {https://oeis.org/A003462},
-  note = {Accessed: 2025-05-22},
+  note = {Accessed: 2025-05-22}
 }
 
 @article{VL20,
@@ -106,5 +117,5 @@
   volume = {23},
   year = {2020},
   pages = {196--206},
-  url = {https://doi.org/10.33581/1561-4085-2020-23-2-196-206},
+  url = {https://doi.org/10.33581/1561-4085-2020-23-2-196-206}
 }

--- a/src/factories/laplacian_factory.jl
+++ b/src/factories/laplacian_factory.jl
@@ -19,6 +19,9 @@ abstract type ClassifiedLaplacian end
     NullGraphLaplacian <: ClassifiedLaplacian
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`NullGraphLaplacian` <: [`ClassifiedLaplacian`](@ref)
 """
 struct NullGraphLaplacian <: ClassifiedLaplacian
     matrix::Matrix{Int}
@@ -28,6 +31,9 @@ end
     EmptyGraphLaplacian <: ClassifiedLaplacian
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`EmptyGraphLaplacian` <: [`ClassifiedLaplacian`](@ref)
 """
 struct EmptyGraphLaplacian <: ClassifiedLaplacian
     matrix::Matrix{Int}
@@ -37,6 +43,9 @@ end
     CompleteGraphLaplacian <: ClassifiedLaplacian
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`CompleteGraphLaplacian` <: [`ClassifiedLaplacian`](@ref)
 """
 struct CompleteGraphLaplacian <: ClassifiedLaplacian
     matrix::Matrix{Int}
@@ -47,6 +56,9 @@ end
     ArbitraryGraphLaplacian <: ClassifiedLaplacian
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`ArbitraryGraphLaplacian` <: [`ClassifiedLaplacian`](@ref)
 """
 struct ArbitraryGraphLaplacian <: ClassifiedLaplacian
     matrix::Matrix{Int}

--- a/src/factories/orthogonality_factory.jl
+++ b/src/factories/orthogonality_factory.jl
@@ -1,0 +1,164 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    KOrthogonality
+
+An abstract type representing the property of `k`-orthogonality of a collection of vectors.
+
+Recall that an (ordered) collection of vectors ``v₁, v₂, ..., vₙ`` is said to be
+*``k``-orthogonal* if we have the inner product ``⟨`vᵢ, vⱼ⟩ = 0`` whenever ``|i - j| ≥ k``
+(i.e., if every pair of vectors at least ``k`` indices apart is orthogonal). This is
+equivalent to the vectors' Gram matrix having bandwidth at most `k`, where we define the
+bandwidth of a matrix ``A`` to be the minimum integer ``k ∈ \\{1, 2, …, n\\}`` such that
+``Aᵢⱼ = 0`` whenever ``|i - j| ≥ k`` [JP25; p. 313](@cite). (Note that many texts instead
+define matrix bandwidth using zero-based indexing—that is, with the condition
+``|i - j| > k`` [Maf14; p. 186](@cite).)
+
+This type is used as a template for concretely defined properties corresponding to specific
+values of ``k``. In the context of the overarching *S*-bandwidth algorithm, we perform a
+different depth-first search for each family of values of ``k`` on our "tree" of
+*S*-eigenvectors to determine whether there exists a ``k``-orthogonal collection of them.
+
+# Interface
+Concrete subtypes of `KOrthogonality` **must** implement the following fields:
+- `k::Int`: the ``k``-orthogonality parameter.
+"""
+abstract type KOrthogonality end
+
+"""
+    Orthogonality <: KOrthogonality
+
+The property of pairwise orthogonality for a collection of vectors.
+
+Recall that a collection of vectors ``v₁, v₂, ..., vₙ`` is said to be pairwise *orthogonal*
+if we have the inner product ``⟨vᵢ, vⱼ⟩ = 0`` whenever ``|i - j| ≥ 1`` (i.e., if every pair
+of vectors is orthogonal). This is equivalent to the vectors' Gram matrix being diagonal.
+
+# Fields
+- `k::Int`: the ``k``-orthogonality parameter; always necessarily ``1``.
+
+# Supertype Hierarchy
+`Orthogonality` <: [`KOrthogonality`](@ref)
+
+# Constructors
+- `Orthogonality()`: constructs a new `Orthogonality` object with `k = 1`.
+"""
+struct Orthogonality <: KOrthogonality
+    k::Int
+
+    Orthogonality() = new(1)
+end
+
+"""
+    QuasiOrthogonality <: KOrthogonality
+
+The property of quasi-orthogonality for a collection of vectors.
+
+Recall that an (ordered) collection of vectors ``v₁, v₂, ..., vₙ`` is said to be
+*quasi-orthogonal* if we have the inner product ``⟨vᵢ, vⱼ⟩ = 0`` whenever ``|i - j| ≥ 2``
+(i.e., if every pair of vectors at least ``2`` indices apart is orthogonal). This is
+equivalent to the vectors' Gram matrix being tridiagonal [JP25; p. 313](@cite).
+
+# Fields
+- `k::Int`: the ``k``-orthogonality parameter; always necessarily ``2``.
+
+# Supertype Hierarchy
+`QuasiOrthogonality` <: [`KOrthogonality`](@ref)
+
+# Constructors
+- `QuasiOrthogonality()`: constructs a new `QuasiOrthogonality` object with `k = 2`.
+"""
+struct QuasiOrthogonality <: KOrthogonality
+    k::Int
+
+    QuasiOrthogonality() = new(2)
+end
+
+"""
+    WeakOrthogonality <: KOrthogonality
+
+The property of "weak orthogonality" for a collection of vectors.
+
+In particular, "weak orthogonality" is an *ad hoc* term used to refer to the property of
+``k``-orthogonality for ``k > 2``. Recall that an (ordered) collection of vectors
+``v₁, v₂, ..., vₙ`` is said to be *`k`-orthogonal* if we have the inner product
+``⟨vᵢ, vⱼ⟩ = 0`` whenever ``|i - j| ≥ k`` (i.e., if every pair of vectors at least ``k``
+indices apart is orthogonal). This is equivalent to the vectors' Gram matrix having
+bandwidth at most ``k``.
+
+# Fields
+- `k::Int`: the ``k``-orthogonality parameter; must be greater than ``2``.
+
+# Supertype Hierarchy
+`WeakOrthogonality` <: [`KOrthogonality`](@ref)
+
+# Notes
+The term "weak orthogonality" is not standard terminology in the literature, but it is used
+here to emphasize the weaker nature of this property compared to orthogonality and
+quasi-orthogonality. It is an *ad hoc* term coined for this module and is not intended to
+be formally introduced in the broader literature.
+"""
+struct WeakOrthogonality <: KOrthogonality
+    k::Int
+
+    function _WeakOrthogonality(k::Integer)
+        if k <= 2
+            throw(DomainError(k, "k-orthogonality parameter must be greater than 2"))
+        end
+
+        return new(Int(k))
+    end
+end
+
+"""
+    classify_k_orthogonality(k)
+
+Classifies the `k`-orthogonality property based on the given `k` parameter.
+
+When searching for a ``k``-orthogonal *S*-basis of a given Laplacian eigenspace, the family
+of values to which our ``k`` parameter belongs informs our choice of algorithm.
+
+# Arguments
+- `k::Integer`: the `k`-orthogonality parameter to classify. Must be a positive integer.
+
+# Returns
+- `::KOrthogonality`: An instance of a concrete [`KOrthogonality`](@ref) subtype
+    corresponding to `k`.
+
+# Throws
+- `DomainError`: if ``k`` is not a positive integer.
+
+# Examples
+```jldoctest
+julia> SDiagonalizability.classify_k_orthogonality(1)
+SDiagonalizability.Orthogonality()
+
+julia> SDiagonalizability.classify_k_orthogonality(2)
+SDiagonalizability.QuasiOrthogonality()
+
+julia> SDiagonalizability.classify_k_orthogonality(3)
+SDiagonalizability.WeakOrthogonality(3)
+
+julia> SDiagonalizability.classify_k_orthogonality(13)
+SDiagonalizability.WeakOrthogonality(13)
+```
+"""
+function classify_k_orthogonality(k::Integer)
+    if k < 1
+        throw(DomainError(k, "k-orthogonality parameter must be a positive integer"))
+    end
+
+    if k == 1
+        prop = Orthogonality()
+    elseif k == 2
+        prop = QuasiOrthogonality()
+    else
+        prop = WeakOrthogonality(k)
+    end
+
+    return prop
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -27,6 +27,9 @@ abstract type AbstractSBandResult end
     SBandMinimizationResult{A,B,C,D} <: AbstractSBandResult
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`SBandMinimizationResult` <: [`AbstractSBandResult`](@ref)
 """
 struct SBandMinimizationResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
@@ -44,6 +47,9 @@ end
     SBandRecognitionResult{A,B,C} <: AbstractSBandResult
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`SBandRecognitionResult` <: [`AbstractSBandResult`](@ref)
 """
 struct SBandRecognitionResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},B<:Tuple,C<:Union{Nothing,Eigen}
@@ -124,6 +130,9 @@ called on a newly created subtype for which no method has been defined.
     hierarchy `A <: B <: C` and the `abstracttype` field is `C`, then both `A` and `B` are
     perfectly valid choices for `subtype`.)
 - `abstracttype::Type`: the abstract type under which the argument is meant to fall.
+
+# Supertype Hierarchy
+`NotImplementedError` <: `Exception`
 
 # Constructors
 - `NotImplementedError(::Function, ::Type, ::Type)`: constructs a new `NotImplementedError`


### PR DESCRIPTION
To get started on the basis search part of our logic, we create the factory and classification of k-orthogonality properties, with full documentation. We also add supertype hierarchy sections to all types that are subtypes in this package.