### PR TITLE
Update description; specify tuple type

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,6 +1,6 @@
 @misc{VJP25,
   author = {Varona, Luis M. B. and Johnston, Nathaniel and Plosker, Sarah},
-  title = {GraphQuantum/SDiagonalizability.jl: A dynamic algorithm to minimize the \emph{S}-bandwidth of an undirected graph},
+  title = {GraphQuantum/SDiagonalizability.jl: A dynamic algorithm to minimize or recognize the \emph{S}-bandwidth of an undirected graph},
   year = {2025},
   url = {https://github.com/GraphQuantum/SDiagonalizability.jl}
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## Overview
 
-*SDiagonalizability.jl* implements the first non-naïve deterministic algorithm to minimize the *S*-bandwidth of an undirected graph with integer edge weights.
+*SDiagonalizability.jl* implements the first non-naïve deterministic algorithm to minimize the *S*-bandwidth of an undirected graph with integer edge weights. Capabilities also exist for determining whether a graph has *S*-bandwidth less than or equal to a fixed integer *k* &ge; 1 without necessarily caring about the true minimum value.
 
 Given an undirected, possibly weighted graph *G* and finite set of integers *S* &subset; **Z**, *G* is said to be "*S*-diagonalizable" if there exists some diagonal matrix *D* and matrix *P* with all entries from *S* such that *G*'s Laplacian matrix *L*(*G*) = *PDP*<sup>-1</sup>. If *G* is *S*-diagonalizable, then its "*S*-bandwidth" is the minimum integer *k* &isin; {1, 2, &hellip;, |*V*(*G*)|} such that there exists some diagonal matrix *D* and matrix *P* with all entries from *S* such that *L*(*G*) = *PDP*<sup>-1</sup> and [*P*<sup>T</sup>*P*]<sub>*i,j*</sub> = 0 whenever |*i* - *j*| &ge; *k*; otherwise, its *S*-bandwidth is simply &infin;.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -43,7 +43,7 @@ CurrentModule = SDiagonalizability
 
 ## Overview
 
-*SDiagonalizability.jl* implements the first non-naïve deterministic algorithm to minimize the ``S``-bandwidth of an undirected graph with integer edge weights.
+*SDiagonalizability.jl* implements the first non-naïve deterministic algorithm to minimize the ``S``-bandwidth of an undirected graph with integer edge weights. Capabilities also exist for determining whether a graph has ``S``-bandwidth less than or equal to a fixed integer ``k \ge 1`` without necessarily caring about the true minimum value.
 
 Given an undirected, possibly weighted graph ``G`` and finite set of integers ``S \subset \mathbb{Z}``, ``G`` is said to be "``S``-diagonalizable" if there exists some diagonal matrix ``D`` and matrix ``P`` with all entries from ``S`` such that ``G``'s Laplacian matrix ``L(G) = PDP^{-1}``. If ``G`` is ``S``-diagonalizable, then its "``S``-bandwidth" is the minimum integer ``k \in \{1, 2, \ldots, |V(G)|\}`` such that there exists some diagonal matrix ``D`` and matrix ``P`` with all entries from ``S`` such that ``L(G) = PDP^{-1}`` and ``[P^\mathsf{T}P]_{i,j} = 0`` whenever ``|i - j| \geq k``; otherwise, its ``S``-bandwidth is simply ``\infty``.
 

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -7,7 +7,7 @@
 """
     SDiagonalizability
 
-A dynamic algorithm to minimize the S-bandwidth of an undirected graph.
+A dynamic algorithm to minimize or recognize the S-bandwidth of an undirected graph.
 
 [TODO: Write here]
 """
@@ -18,19 +18,20 @@ using DataStructures
 using ElasticArrays
 using Graphs
 using LinearAlgebra
+using MatrixBandwidth
 
 include("utils.jl")
 include("types.jl")
 
 include("factories/laplacian_factory.jl")
-# include("factories/orthogonality_factory.jl")
+include("factories/orthogonality_factory.jl")
 
 include("eigenvector_generation.jl")
 include("laplacian_s_spectra.jl")
-# include("basis_search.jl")
+include("basis_search.jl")
 
-# include("core.jl")
+include("core.jl")
 
-# export minimize_s_bandwidths, has_s_bands_at_most_k, is_s_diagonalizable
+export minimize_s_bandwidth, has_s_bandwidth_at_most_k, is_s_diagonalizable
 
 end

--- a/src/basis_search.jl
+++ b/src/basis_search.jl
@@ -1,0 +1,7 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+# TODO: Write here

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,0 +1,57 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    minimize_s_bandwidth(g::AbstractGraph, S)
+    minimize_s_bandwidth(L::AbstractMatrix{<:Integer}, S)
+
+[TODO: Write here]
+"""
+function minimize_s_bandwidth(g::AbstractGraph, S::Tuple{Vararg{Int}})
+    _assert_graph_has_defined_s_bandwidth(g)
+    return minimize_s_bandwidth(laplacian_matrix(g), S)
+end
+
+function minimize_s_bandwidth(L::AbstractMatrix{<:Integer}, S::Tuple{Vararg{Int}})
+    _assert_matrix_is_undirected_laplacian(L)
+    # TODO: Write here
+    return nothing
+end
+
+"""
+    has_s_bandwidth_at_most_k(g::AbstractGraph, S, k)
+    has_s_bandwidth_at_most_k(L::AbstractMatrix{<:Integer}, S, k)
+
+[TODO: Write here]
+"""
+function has_s_bandwidth_at_most_k(g::AbstractGraph, S::Tuple{Vararg{Int}}, k::Int)
+    _assert_graph_has_defined_s_bandwidth(g)
+    return has_s_bandwidth_at_most_k(laplacian_matrix(g), S, k)
+end
+
+function has_s_bandwidth_at_most_k(
+    L::AbstractMatrix{<:Integer}, S::Tuple{Vararg{Int}}, k::Int
+)
+    _assert_matrix_is_undirected_laplacian(L)
+    # TODO: Write here
+    return nothing
+end
+
+"""
+    is_s_diagonalizable(g::AbstractGraph, S)
+    is_s_diagonalizable(L::AbstractMatrix{<:Integer}, S)
+
+[TODO: Write here]
+"""
+function is_s_diagonalizable(g::AbstractGraph, S::Tuple{Vararg{Int}})
+    _assert_graph_has_defined_s_bandwidth(g)
+    return is_s_diagonalizable(laplacian_matrix(g), S)
+end
+
+function is_s_diagonalizable(L::AbstractMatrix{<:Integer}, S::Tuple{Vararg{Int}})
+    _assert_matrix_is_undirected_laplacian(L)
+    return has_s_bandwidth_at_most_k(L, S, size(L, 1))
+end

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -21,7 +21,7 @@
 # Examples
 [TODO: Write here]
 """
-function pot_kernel_s_eigvecs(n::Integer, S::Tuple)
+function pot_kernel_s_eigvecs(n::Integer, S::Tuple{Vararg{Int}})
     if n < 0
         throw(DomainError(n, "Laplacian order must be non-negative"))
     end
@@ -54,7 +54,7 @@ end
 # Examples
 [TODO: Write here]
 """
-function pot_nonkernel_s_eigvecs(n::Integer, S::Tuple)
+function pot_nonkernel_s_eigvecs(n::Integer, S::Tuple{Vararg{Int}})
     if n < 0
         throw(DomainError(n, "Laplacian order must be non-negative"))
     end

--- a/src/laplacian_s_spectra.jl
+++ b/src/laplacian_s_spectra.jl
@@ -9,7 +9,7 @@
 
 [TODO: Write here. Also, comment inline]
 """
-function laplacian_s_spectra(L::AbstractMatrix{<:Integer}, S::Tuple)
+function laplacian_s_spectra(L::AbstractMatrix{<:Integer}, S::Tuple{Vararg{Int}})
     _assert_matrix_is_undirected_laplacian(L)
 
     if S == (-1, 0, 1)
@@ -400,7 +400,7 @@ end
 
 [TODO: Write here]
 """
-function _classified_laplacian_s_spectra(CL::ArbitraryGraphLaplacian, S::Tuple)
+function _classified_laplacian_s_spectra(CL::ArbitraryGraphLaplacian, S::Tuple{Vararg{Int}})
     L = CL.matrix
     res = check_spectrum_integrality(L)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,7 +12,7 @@ Abstract base type for all *S*-bandwidth problem results.
 # Interface
 Concrete subtypes of `AbstractSBandResult` *must* implement parametric types
 - `A<:Union{AbstractGraph,AbstractMatrix{<:Integer}}`;
-- `B<:Tuple`; and
+- `B<:Tuple{Vararg{Int}}`; and
 - `C<:Union{Nothing,Eigen}`,
 
 alongside the following fields:
@@ -33,7 +33,7 @@ abstract type AbstractSBandResult end
 """
 struct SBandMinimizationResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
-    B<:Tuple,
+    B<:Tuple{Vararg{Int}},
     C<:Union{Nothing,Eigen},
     D<:Union{Int,Float64},
 } <: AbstractSBandResult
@@ -52,7 +52,9 @@ end
 `SBandRecognitionResult` <: [`AbstractSBandResult`](@ref)
 """
 struct SBandRecognitionResult{
-    A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},B<:Tuple,C<:Union{Nothing,Eigen}
+    A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
+    B<:Tuple{Vararg{Int}},
+    C<:Union{Nothing,Eigen},
 } <: AbstractSBandResult
     network::A
     S::B
@@ -68,7 +70,7 @@ end
 """
 struct SSpectra{
     A<:AbstractMatrix{<:Integer},
-    B<:Tuple,
+    B<:Tuple{Vararg{Int}},
     C<:Union{Nothing,OrderedDict{Int,Int}},
     D<:Union{Nothing,OrderedDict{Int,AbstractMatrix{Int}}},
     E<:Union{Nothing,OrderedDict{Int,Matrix{Int}}},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -127,6 +127,28 @@ function _assert_matrix_is_undirected_laplacian(L::AbstractMatrix{<:Integer})
 end
 
 """
+    _assert_graph_has_defined_s_bandwidth(g) -> Nothing
+
+[TODO: Write here]
+"""
+function _assert_graph_has_defined_s_bandwidth(g::AbstractGraph)
+    if is_directed(g)
+        throw(DomainError(g, "*S*-bandwidth is not defined for directed graphs"))
+    end
+
+    if has_self_loops(g)
+        throw(
+            DomainError(
+                graph,
+                "*S*-bandwidth is not defined for multigraphs; got a graph with self-loops",
+            ),
+        )
+    end
+
+    return nothing
+end
+
+"""
     function _rank_rtol(A::AbstractMatrix{<:Real}) -> Float64
 
 Return a reasonable relative tolerance for computing matrix rank via SVD or QRD.


### PR DESCRIPTION
This PR updates the description everywhere relevant to indicate that we also have capabilities for _S_-bandwidth recognition. It also further specifies the type of the `S` parameter from 'Tuple' to 'Tuple{Vararg{Int}}'. Finally, it started creating skeleton functions for `src/core.jl`.