### PR TITLE
Made several changes; see extended message

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,210 @@ pkg> add SDiagonalizability
 
 ## Basic use
 
-[TODO: Write here]
+*SDiagonalizability.jl* offers capabilities for *S*-bandwidth minimization, *S*-bandwidth recognition, and plain old *S*-diagonalizability checking. To compute the *S*-bandwidth of a graph, you can use the `s_bandwidth` function:
+
+```julia-repl
+julia> using Graphs
+
+julia> g = complete_graph(14)
+{14, 91} undirected simple Int64 graph
+
+julia> res_01neg = s_bandwidth(g, (-1, 0, 1))
+Results of S-Bandwidth Minimization
+ * S: (-1, 0, 1)
+ * S-Bandwidth: 2
+ * Graph Order: 14
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+14-element Vector{Int64}:
+  0
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+vectors:
+14×14 Matrix{Int64}:
+ 1   0   0   0   0   1   1   1   1   1   1   0   0   0
+ 1   0   0   0   0  -1   0  -1   1   1   1   0   0   0
+ 1   0   0   0   0   0  -1   1   0   1   1   0   0   0
+ 1   0   0   0   0   0   0  -1   0   1  -1   0   0   0
+ 1   0   0   0   0   0   0   0  -1  -1   1   1   1   1
+ 1   0   0   0   0   0   0   0  -1  -1   1  -1  -1  -1
+ 1   1   1   0   0   0   0   0   0  -1   0   0  -1   1
+ 1  -1  -1   0   0   0   0   0   0  -1   0   0   0  -1
+ 1   0  -1   1   1   0   0   0   0   0  -1   0   0   0
+ 1   0   0  -1  -1   0   0   0   0   0  -1   0   0   0
+ 1   0   0   0  -1   0   0   0   0   0  -1   0   0   0
+ 1   0   1   0   1   0   0   0   0   0  -1   0   0   0
+ 1  -1  -1   0   0   0   0   0   0   0   0   0   0   1
+ 1   1   1   0   0   0   0   0   0   0   0   0   1  -1
+
+julia> res_1neg = s_bandwidth(g, (-1, 1))
+Results of S-Bandwidth Minimization
+ * S: (-1, 1)
+ * S-Bandwidth: 13
+ * Graph Order: 14
+
+julia> res_1neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+14-element Vector{Int64}:
+  0
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+vectors:
+14×14 Matrix{Int64}:
+ 1   1   1   1   1   1   1   1   1   1   1   1   1   1
+ 1  -1  -1  -1  -1  -1  -1   1   1   1   1   1   1   1
+ 1  -1  -1  -1   1   1   1  -1  -1  -1   1   1   1   1
+ 1  -1  -1  -1   1   1   1   1   1   1  -1  -1  -1   1
+ 1  -1  -1  -1   1   1   1   1   1   1   1   1   1  -1
+ 1  -1   1   1  -1  -1   1  -1  -1   1  -1  -1   1  -1
+ 1  -1   1   1  -1   1  -1  -1   1  -1  -1   1  -1  -1
+ 1  -1   1   1   1  -1  -1   1  -1  -1   1  -1  -1   1
+ 1   1  -1   1  -1  -1   1  -1   1  -1   1  -1  -1   1
+ 1   1  -1   1  -1   1  -1   1  -1  -1  -1  -1   1  -1
+ 1   1  -1   1   1  -1  -1  -1  -1   1  -1   1  -1  -1
+ 1   1   1  -1  -1  -1   1   1  -1  -1  -1   1  -1  -1
+ 1   1   1  -1  -1   1  -1  -1  -1   1   1  -1  -1   1
+ 1   1   1  -1   1  -1  -1  -1   1  -1  -1  -1   1  -1
+```
+
+Alternatively, to determine whether a graph has *S*-bandwidth less than or equal to some fixed integer *k* &ge; 1 without
+necessarily caring about the true (minimum) value, you can take advantage of `has_s_bandwidth_at_most_k`:
+
+```julia-repl
+julia> using Graphs
+
+julia> g = PetersenGraph()
+{10, 15} undirected simple Int64 graph
+
+julia> res_01neg = has_s_bandwidth_at_most_k(g, (-1, 0, 1), 4)
+Results of S-Bandwidth Recognition
+ * S: (-1, 0, 1)
+ * S-Bandwidth Threshold k: 4
+ * Has S-Bandwidth ≤ k: true
+ * Graph Order: 10
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+10-element Vector{Int64}:
+ 0
+ 5
+ 5
+ 5
+ 5
+ 2
+ 2
+ 2
+ 2
+ 2
+vectors:
+10×10 Matrix{Int64}:
+ 1   1   1   0   0   1   1   1   1   1
+ 1  -1  -1   1   1   0   0   0   0   1
+ 1   0   1  -1  -1   0  -1   0  -1  -1
+ 1   0   0   0   1   0   0   0  -1  -1
+ 1   0  -1   0  -1   1   1   0   0   0
+ 1  -1   0  -1   0   0   0   1   1   0
+ 1   1   0  -1  -1  -1   0  -1   0   1
+ 1   1  -1   1   0   0  -1   0   0  -1
+ 1   0   0   1   0  -1   0   0   0   0
+ 1  -1   1   0   1   0   0  -1   0   0
+
+julia> res_1neg = has_s_bandwidth_at_most_k(g, (-1, 1), 10)
+Results of S-Bandwidth Recognition
+ * S: (-1, 1)
+ * S-Bandwidth Threshold k: 10
+ * Has S-Bandwidth ≤ k: false
+ * Graph Order: 10
+
+julia> isnothing(res_1neg.s_diagonalization)
+true
+```
+
+Lastly, the `is_s_diagonalizable` function can be used to simply determine whether a graph is *S*-diagonalizable:
+
+```julia-repl
+julia> using Graphs
+
+julia> L = laplacian_matrix(complete_multipartite_graph([1, 1, 2, 2, 3]))
+9×9 SparseArrays.SparseMatrixCSC{Int64, Int64} with 71 stored entries:
+  8  -1  -1  -1  -1  -1  -1  -1  -1
+ -1   8  -1  -1  -1  -1  -1  -1  -1
+ -1  -1   7   ⋅  -1  -1  -1  -1  -1
+ -1  -1   ⋅   7  -1  -1  -1  -1  -1
+ -1  -1  -1  -1   7   ⋅  -1  -1  -1
+ -1  -1  -1  -1   ⋅   7  -1  -1  -1
+ -1  -1  -1  -1  -1  -1   6   ⋅   ⋅
+ -1  -1  -1  -1  -1  -1   ⋅   6   ⋅
+ -1  -1  -1  -1  -1  -1   ⋅   ⋅   6
+
+julia> res_01neg = is_s_diagonalizable(L, (-1, 0, 1))
+Results of S-Diagonalizability Check
+ * S: (-1, 0, 1)
+ * S-Diagonalizable: true
+ * Graph Order: 9
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+9-element Vector{Int64}:
+ 0
+ 6
+ 6
+ 7
+ 7
+ 9
+ 9
+ 9
+ 9
+vectors:
+9×9 Matrix{Int64}:
+ 1   0   0   0   0   1   1   1   1
+ 1   0   0   0   0   0  -1  -1   1
+ 1   0   0   1   1  -1  -1   1  -1
+ 1   0   0  -1  -1  -1  -1   1  -1
+ 1   0   0  -1   1  -1   1  -1   0
+ 1   0   0   1  -1  -1   1  -1   0
+ 1   1   1   0   0   1   0   0   0
+ 1  -1   0   0   0   1   0   0   0
+ 1   0  -1   0   0   1   0   0   0
+
+julia> res_1neg = is_s_diagonalizable(L, (-1, 1))
+Results of S-Diagonalizability Check
+ * S: (-1, 1)
+ * S-Diagonalizable: false
+ * Graph Order: 9
+
+julia> isnothing(res_1neg.s_diagonalization)
+true
+```
+
+(As demonstrated in this last example, you can supply the Laplacian matrix of a graph as an alternative to the `Graph` object itself from the *Graphs.jl* package.)
 
 ## Documentation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,7 +65,210 @@ pkg> add SDiagonalizability
 
 ## Basic use
 
-[TODO: Write here]
+*SDiagonalizability.jl* offers capabilities for ``S``-bandwidth minimization, ``S``-bandwidth recognition, and plain old ``S``-diagonalizability checking. To compute the ``S``-bandwidth of a graph, you can use the `s_bandwidth` function:
+
+```julia-repl
+julia> using Graphs
+
+julia> g = complete_graph(14)
+{14, 91} undirected simple Int64 graph
+
+julia> res_01neg = s_bandwidth(g, (-1, 0, 1))
+Results of S-Bandwidth Minimization
+ * S: (-1, 0, 1)
+ * S-Bandwidth: 2
+ * Graph Order: 14
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+14-element Vector{Int64}:
+  0
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+vectors:
+14×14 Matrix{Int64}:
+ 1   0   0   0   0   1   1   1   1   1   1   0   0   0
+ 1   0   0   0   0  -1   0  -1   1   1   1   0   0   0
+ 1   0   0   0   0   0  -1   1   0   1   1   0   0   0
+ 1   0   0   0   0   0   0  -1   0   1  -1   0   0   0
+ 1   0   0   0   0   0   0   0  -1  -1   1   1   1   1
+ 1   0   0   0   0   0   0   0  -1  -1   1  -1  -1  -1
+ 1   1   1   0   0   0   0   0   0  -1   0   0  -1   1
+ 1  -1  -1   0   0   0   0   0   0  -1   0   0   0  -1
+ 1   0  -1   1   1   0   0   0   0   0  -1   0   0   0
+ 1   0   0  -1  -1   0   0   0   0   0  -1   0   0   0
+ 1   0   0   0  -1   0   0   0   0   0  -1   0   0   0
+ 1   0   1   0   1   0   0   0   0   0  -1   0   0   0
+ 1  -1  -1   0   0   0   0   0   0   0   0   0   0   1
+ 1   1   1   0   0   0   0   0   0   0   0   0   1  -1
+
+julia> res_1neg = s_bandwidth(g, (-1, 1))
+Results of S-Bandwidth Minimization
+ * S: (-1, 1)
+ * S-Bandwidth: 13
+ * Graph Order: 14
+
+julia> res_1neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+14-element Vector{Int64}:
+  0
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+ 14
+vectors:
+14×14 Matrix{Int64}:
+ 1   1   1   1   1   1   1   1   1   1   1   1   1   1
+ 1  -1  -1  -1  -1  -1  -1   1   1   1   1   1   1   1
+ 1  -1  -1  -1   1   1   1  -1  -1  -1   1   1   1   1
+ 1  -1  -1  -1   1   1   1   1   1   1  -1  -1  -1   1
+ 1  -1  -1  -1   1   1   1   1   1   1   1   1   1  -1
+ 1  -1   1   1  -1  -1   1  -1  -1   1  -1  -1   1  -1
+ 1  -1   1   1  -1   1  -1  -1   1  -1  -1   1  -1  -1
+ 1  -1   1   1   1  -1  -1   1  -1  -1   1  -1  -1   1
+ 1   1  -1   1  -1  -1   1  -1   1  -1   1  -1  -1   1
+ 1   1  -1   1  -1   1  -1   1  -1  -1  -1  -1   1  -1
+ 1   1  -1   1   1  -1  -1  -1  -1   1  -1   1  -1  -1
+ 1   1   1  -1  -1  -1   1   1  -1  -1  -1   1  -1  -1
+ 1   1   1  -1  -1   1  -1  -1  -1   1   1  -1  -1   1
+ 1   1   1  -1   1  -1  -1  -1   1  -1  -1  -1   1  -1
+```
+
+Alternatively, to determine whether a graph has ``S``-bandwidth less than or equal to some fixed integer ``k \ge 1`` without
+necessarily caring about the true (minimum) value, you can take advantage of `has_s_bandwidth_at_most_k`:
+
+```julia-repl
+julia> using Graphs
+
+julia> g = PetersenGraph()
+{10, 15} undirected simple Int64 graph
+
+julia> res_01neg = has_s_bandwidth_at_most_k(g, (-1, 0, 1), 4)
+Results of S-Bandwidth Recognition
+ * S: (-1, 0, 1)
+ * S-Bandwidth Threshold k: 4
+ * Has S-Bandwidth ≤ k: true
+ * Graph Order: 10
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+10-element Vector{Int64}:
+ 0
+ 5
+ 5
+ 5
+ 5
+ 2
+ 2
+ 2
+ 2
+ 2
+vectors:
+10×10 Matrix{Int64}:
+ 1   1   1   0   0   1   1   1   1   1
+ 1  -1  -1   1   1   0   0   0   0   1
+ 1   0   1  -1  -1   0  -1   0  -1  -1
+ 1   0   0   0   1   0   0   0  -1  -1
+ 1   0  -1   0  -1   1   1   0   0   0
+ 1  -1   0  -1   0   0   0   1   1   0
+ 1   1   0  -1  -1  -1   0  -1   0   1
+ 1   1  -1   1   0   0  -1   0   0  -1
+ 1   0   0   1   0  -1   0   0   0   0
+ 1  -1   1   0   1   0   0  -1   0   0
+
+julia> res_1neg = has_s_bandwidth_at_most_k(g, (-1, 1), 10)
+Results of S-Bandwidth Recognition
+ * S: (-1, 1)
+ * S-Bandwidth Threshold k: 10
+ * Has S-Bandwidth ≤ k: false
+ * Graph Order: 10
+
+julia> isnothing(res_1neg.s_diagonalization)
+true
+```
+
+Lastly, the `is_s_diagonalizable` function can be used to simply determine whether a graph is ``S``-diagonalizable:
+
+```julia-repl
+julia> using Graphs
+
+julia> L = laplacian_matrix(complete_multipartite_graph([1, 1, 2, 2, 3]))
+9×9 SparseArrays.SparseMatrixCSC{Int64, Int64} with 71 stored entries:
+  8  -1  -1  -1  -1  -1  -1  -1  -1
+ -1   8  -1  -1  -1  -1  -1  -1  -1
+ -1  -1   7   ⋅  -1  -1  -1  -1  -1
+ -1  -1   ⋅   7  -1  -1  -1  -1  -1
+ -1  -1  -1  -1   7   ⋅  -1  -1  -1
+ -1  -1  -1  -1   ⋅   7  -1  -1  -1
+ -1  -1  -1  -1  -1  -1   6   ⋅   ⋅
+ -1  -1  -1  -1  -1  -1   ⋅   6   ⋅
+ -1  -1  -1  -1  -1  -1   ⋅   ⋅   6
+
+julia> res_01neg = is_s_diagonalizable(L, (-1, 0, 1))
+Results of S-Diagonalizability Check
+ * S: (-1, 0, 1)
+ * S-Diagonalizable: true
+ * Graph Order: 9
+
+julia> res_01neg.s_diagonalization
+LinearAlgebra.Eigen{Int64, Int64, Matrix{Int64}, Vector{Int64}}
+values:
+9-element Vector{Int64}:
+ 0
+ 6
+ 6
+ 7
+ 7
+ 9
+ 9
+ 9
+ 9
+vectors:
+9×9 Matrix{Int64}:
+ 1   0   0   0   0   1   1   1   1
+ 1   0   0   0   0   0  -1  -1   1
+ 1   0   0   1   1  -1  -1   1  -1
+ 1   0   0  -1  -1  -1  -1   1  -1
+ 1   0   0  -1   1  -1   1  -1   0
+ 1   0   0   1  -1  -1   1  -1   0
+ 1   1   1   0   0   1   0   0   0
+ 1  -1   0   0   0   1   0   0   0
+ 1   0  -1   0   0   1   0   0   0
+
+julia> res_1neg = is_s_diagonalizable(L, (-1, 1))
+Results of S-Diagonalizability Check
+ * S: (-1, 1)
+ * S-Diagonalizable: false
+ * Graph Order: 9
+
+julia> isnothing(res_1neg.s_diagonalization)
+true
+```
+
+(As demonstrated in this last example, you can supply the Laplacian matrix of a graph as an alternative to the `Graph` object itself from the *Graphs.jl* package.)
 
 ## Documentation
 

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -32,6 +32,6 @@ include("basis_search.jl")
 
 include("core.jl")
 
-export minimize_s_bandwidth, has_s_bandwidth_at_most_k, is_s_diagonalizable
+export s_bandwidth, has_s_bandwidth_at_most_k, is_s_diagonalizable
 
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,12 +5,12 @@
 # distributed except according to those terms.
 
 """
-    AbstractSBandResult
+    AbstractSDiagResult
 
-Abstract base type for all *S*-bandwidth problem results.
+Abstract base type for all *S*-diagonalizability and *S*-bandwidth problem results.
 
 # Interface
-Concrete subtypes of `AbstractSBandResult` *must* implement parametric types
+Concrete subtypes of `AbstractSDiagResult` *must* implement parametric types
 - `A<:Union{AbstractGraph,AbstractMatrix{<:Integer}}`;
 - `B<:Tuple{Vararg{Integer}}`; and
 - `C<:Union{Nothing,Eigen}`,
@@ -21,46 +21,114 @@ alongside the following fields:
 - `diagonalization::C`: an *S*-diagonalization of the matrix representation of the network,
     if it satisfies the specified *S*-bandwidth constraints; otherwise, `nothing`.
 """
-abstract type AbstractSBandResult end
+abstract type AbstractSDiagResult end
 
 """
-    SBandMinimizationResult{A,B,C,D} <: AbstractSBandResult
+    SBandMinimizationResult{A,B,C,D} <: AbstractSDiagResult
 
 [TODO: Write here]
 
 # Supertype Hierarchy
-`SBandMinimizationResult` <: [`AbstractSBandResult`](@ref)
+`SBandMinimizationResult` <: [`AbstractSDiagResult`](@ref)
 """
 struct SBandMinimizationResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
     B<:Tuple{Vararg{Integer}},
     C<:Union{Nothing,Eigen},
     D<:Union{Int,Float64},
-} <: AbstractSBandResult
+} <: AbstractSDiagResult
     network::A
     S::B
-    diagonalization::C
-    band::D
+    s_diagonalization::C
+    s_bandwidth::D
+end
+
+#= The `Base.show` override here takes heavy inspiration from the `MatrixBandwidth.jl`
+package (written by myself), which in turn took inspiration from `Optim.jl`. =#
+function Base.show(io::IO, res::SBandMinimizationResult{A}) where {A}
+    if A<:AbstractGraph
+        n = nv(res.network)
+    else
+        n = size(res.network, 1)
+    end
+
+    println(io, "Results of S-Bandwidth Minimization")
+    println(io, " * S: $(Int.(res.S))")
+    println(io, " * S-Bandwidth: $(res.s_bandwidth)")
+    print(io, " * Graph Order: $n")
+
+    return nothing
 end
 
 """
-    SBandRecognitionResult{A,B,C} <: AbstractSBandResult
+    SBandRecognitionResult{A,B,C} <: AbstractSDiagResult
 
 [TODO: Write here]
 
 # Supertype Hierarchy
-`SBandRecognitionResult` <: [`AbstractSBandResult`](@ref)
+`SBandRecognitionResult` <: [`AbstractSDiagResult`](@ref)
 """
 struct SBandRecognitionResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
     B<:Tuple{Vararg{Integer}},
     C<:Union{Nothing,Eigen},
-} <: AbstractSBandResult
+} <: AbstractSDiagResult
     network::A
     S::B
-    diagonalization::C
+    s_diagonalization::C
     k::Integer
-    has_band_k_diag::Bool
+    s_band_at_most_k::Bool
+end
+
+#= The `Base.show` override here takes heavy inspiration from the `MatrixBandwidth.jl`
+package (written by myself), which in turn took inspiration from `Optim.jl`. =#
+function Base.show(io::IO, res::SBandRecognitionResult{A}) where {A}
+    if A<:AbstractGraph
+        n = nv(res.network)
+    else
+        n = size(res.network, 1)
+    end
+
+    println(io, "Results of S-Bandwidth Recognition")
+    println(io, " * S: $(Int.(res.S))")
+    println(io, " * S-Bandwidth Threshold k: $(res.k)")
+    println(io, " * Has S-Bandwidth ≤ k: $(res.s_band_at_most_k)")
+    print(io, " * Graph Order: $n")
+
+    return nothing
+end
+
+"""
+    SDiagonalizabilityResult{A,B,C} <: AbstractSDiagResult
+
+[TODO: Write here]
+"""
+struct SDiagonalizabilityResult{
+    A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},
+    B<:Tuple{Vararg{Integer}},
+    C<:Union{Nothing,Eigen},
+} <: AbstractSDiagResult
+    network::A
+    S::B
+    s_diagonalization::C
+    has_s_diagonalization::Bool
+end
+
+#= The `Base.show` override here takes heavy inspiration from the `MatrixBandwidth.jl`
+package (written by myself), which in turn took inspiration from `Optim.jl`. =#
+function Base.show(io::IO, res::SDiagonalizabilityResult{A}) where {A}
+    if A<:AbstractGraph
+        n = nv(res.network)
+    else
+        n = size(res.network, 1)
+    end
+
+    println(io, "Results of S-Diagonalizability Check")
+    println(io, " * S: $(Int.(res.S))")
+    println(io, " * S-Diagonalizable: $(res.has_s_diagonalization)")
+    print(io, " * Graph Order: $n")
+
+    return nothing
 end
 
 """


### PR DESCRIPTION
First, the 'minimize_s_bandwidth' function is renamed to 's_bandwidth'.

Second, further results/useful checks from Johnston and Plosker (2025) are integrated into the core logic.

Third, the 's_bandwidth' function is updated to not run redundant checks on eigenspaces for a k-basis if the previous run failed for some other eigenspaces; in this way, it is no longer a wrapper around the recognition algorithm due to non-independent runs for each k.

Fourth, 'is_s_diagonalizable' now returns its own 'SDiagonalizabilityResult' struct, not just a somewhat semantically inappropriate 'SBandRecognitionResult'.

Finally, the 'Basic Use' section is completed in the README, with the Base.show methods for the result structs overriden.