### PR TITLE
Integrate PrecompileTools; bugfix for is_s_diagonalizable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,15 +2,12 @@ name = "SDiagonalizability"
 uuid = "addecc1e-711d-4b49-877e-3152f1574f63"
 keywords = ["graph theory", "linear algebra", "dynamic programming", "quantum computing"]
 license = "MIT"
-authors=[
-    "Luis M. B. Varona <lm.varona@outlook.com>",
-    "Nathaniel Johnston <nathaniel.johnston@gmail.com>",
-]
+authors = ["Luis M. B. Varona <lm.varona@outlook.com>", "Nathaniel Johnston <nathaniel.johnston@gmail.com>"]
 description = "A dynamic algorithm to minimize the S-bandwidth of an undirected graph, written in Julia."
+homepage = "https://graphquantum.github.io/SDiagonalizability.jl/"
 maintainers = ["Luis M. B. Varona <lm.varona@outlook.com>"]
 readme = "README.md"
 repository = "https://github.com/GraphQuantum/SDiagonalizability.jl"
-homepage = "https://graphquantum.github.io/SDiagonalizability.jl/"
 version = "0.1.0-dev"
 
 [deps]
@@ -20,6 +17,7 @@ ElasticArrays = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MatrixBandwidth = "075aa41b-24fd-4573-b25f-92cae432c0f8"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Combinatorics = "1.0"
@@ -28,4 +26,5 @@ ElasticArrays = "1.2"
 Graphs = "1.10"
 LinearAlgebra = "1.10"
 MatrixBandwidth = "0.1 - 0.2"
+PrecompileTools = "1.2"
 julia = "1.10"

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -19,6 +19,7 @@ using ElasticArrays
 using Graphs
 using LinearAlgebra
 using MatrixBandwidth
+using PrecompileTools: @setup_workload, @compile_workload
 
 include("utils.jl")
 include("types.jl")
@@ -31,6 +32,8 @@ include("laplacian_s_spectra.jl")
 include("basis_search.jl")
 
 include("core.jl")
+
+include("startup.jl")
 
 export s_bandwidth, has_s_bandwidth_at_most_k, is_s_diagonalizable
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -169,8 +169,8 @@ function is_s_diagonalizable(g::AbstractGraph, S::Tuple{Vararg{Integer}})
 
     res = is_s_diagonalizable(laplacian_matrix(g), S)
 
-    return SBandRecognitionResult(
-        copy(g), res.S, res.s_diagonalization, nv(g), res.s_band_at_most_k
+    return SDiagonalizabilityResult(
+        copy(g), res.S, res.s_diagonalization, res.has_s_diagonalization
     )
 end
 

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -1,0 +1,27 @@
+# Copyright 2025 Luis M. B. Varona, Nathaniel Johnston, and Sarah Plosker
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+@setup_workload begin
+    g = complete_graph(6)
+    L_g = laplacian_matrix(g)
+
+    h = cartesian_product(complete_graph(2), complete_graph(4))
+    L_h = laplacian_matrix(h)
+
+    @compile_workload begin
+        for network in [g, L_g, h, L_h]
+            for S in [(-1, 0, 1), (-1, 1)]
+                s_bandwidth(network, S)
+
+                for k in [1, 2, 5]
+                    has_s_bandwidth_at_most_k(network, S, k)
+                end
+
+                is_s_diagonalizable(network, S)
+            end
+        end
+    end
+end


### PR DESCRIPTION
This PR integrates PrecompileTools.jl into the package to reduce delay on first use. It also implements a bugfix for is_s_diagonalizable (the method for graph input was previously still returning an SBandRecognitionResult instead of an SDiagonalizabilityResult and throwing an error as well).