### PR TITLE
Prepare for v0.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ homepage = "https://graphquantum.github.io/SDiagonalizability.jl/"
 maintainers = ["Luis M. B. Varona <lm.varona@outlook.com>"]
 readme = "README.md"
 repository = "https://github.com/GraphQuantum/SDiagonalizability.jl"
-version = "0.1.0-dev"
+version = "0.1.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <tr>
     <td>Metadata</td>
     <td>
-      <img src="https://img.shields.io/badge/version-v0.1.0--dev-pink.svg" alt="Version">
+      <img src="https://img.shields.io/badge/version-v0.1.0-pink.svg" alt="Version">
       <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-A31F34.svg" alt="License: MIT"></a>
       <a href="https://github.com/JuliaDiff/BlueStyle"><img src="https://img.shields.io/badge/code%20style-blue-4495d1.svg" alt="Code Style: Blue"></a>
     </td>
@@ -51,10 +51,6 @@ For specific choices of *S* (namely {-1, 1} and {-1, 0, 1}), the *S*-bandwidth o
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
-
-```julia-repl
-pkg> add https://github.com/GraphQuantum/SDiagonalizability.jl
-```
 
 Once *SDiagonalizability.jl* is added to Julia's General package registry, you will be able to install it more easily with:
 
@@ -271,7 +267,7 @@ true
 
 ## Documentation
 
-The full documentation is available at [GitHub Pages](https://graphquantum.github.io/SDiagonalizability.jl/). Documentation for methods and types is also available via the Julia REPL. [TODO: Write here]
+The full documentation is available at [GitHub Pages](https://graphquantum.github.io/SDiagonalizability.jl/). Documentation for methods and types is also available via the Julia REPL. (Note that as we have just completed development of the core API, many symbols lack complete documentation at this time&mdash;we aim to rectify this with the release of v0.1.1.)
 
 ## Citing
 
@@ -281,7 +277,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-We aim to release the first stable version of *SDiagonalizability.jl* sometime in early August 2025. The current codebase is a work-in-progress, with the main `SDiagonalizability` module not yet functional and comprehensive documentation/tests not yet available.
+The latest stable release of *SDiagonalizability.jl* is v0.1.0. Although a good chunk of documentation and tests is still missing, the core API is fully functional and the package is ready for use. We are currently working on filling in the gaps and aim to release a more polished update (v0.1.1) in the near future.
 
 ## Credits
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,7 @@ CurrentModule = SDiagonalizability
   <tr>
     <td>Metadata</td>
     <td>
-      <img src="https://img.shields.io/badge/version-v0.1.0--dev-pink.svg" alt="Version">
+      <img src="https://img.shields.io/badge/version-v0.1.0-pink.svg" alt="Version">
       <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-A31F34.svg" alt="License: MIT"></a>
       <a href="https://github.com/JuliaDiff/BlueStyle"><img src="https://img.shields.io/badge/code%20style-blue-4495d1.svg" alt="Code Style: Blue"></a>
     </td>
@@ -59,10 +59,6 @@ For specific choices of ``S`` (namely ``\{-1, 1\}`` and ``\{-1, 0, 1\}``), the `
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
-
-```julia-repl
-pkg> add https://github.com/GraphQuantum/SDiagonalizability.jl
-```
 
 Once *SDiagonalizability.jl* is added to Julia's General package registry, you will be able to install it more easily with:
 
@@ -279,7 +275,7 @@ true
 
 ## Documentation
 
-The full documentation is available at [GitHub Pages](https://graphquantum.github.io/SDiagonalizability.jl/). Documentation for methods and types is also available via the Julia REPL. [TODO: Write here]
+The full documentation is available at [GitHub Pages](https://graphquantum.github.io/SDiagonalizability.jl/). Documentation for methods and types is also available via the Julia REPL. (Note that as we have just completed development of the core API, many symbols lack complete documentation at this time—we aim to rectify this with the release of v0.1.1.)
 
 ## Citing
 
@@ -289,7 +285,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-We aim to release the first stable version of *SDiagonalizability.jl* sometime in early August 2025. The current codebase is a work-in-progress, with the main `SDiagonalizability` module not yet functional and comprehensive documentation/tests not yet available.
+The latest stable release of *SDiagonalizability.jl* is v0.1.0. Although a good chunk of documentation and tests is still missing, the core API is fully functional and the package is ready for use. We are currently working on filling in the gaps and aim to release a more polished update (v0.1.1) in the near future.
 
 ## Credits
 

--- a/docs/src/public_api.md
+++ b/docs/src/public_api.md
@@ -16,6 +16,6 @@ Private = false
 
 ## References
 
-<!-- ```@bibliography
+```@bibliography
 Pages = [@__FILE__]
-``` -->
+```

--- a/src/SDiagonalizability.jl
+++ b/src/SDiagonalizability.jl
@@ -9,16 +9,37 @@
 
 A dynamic algorithm to minimize or recognize the S-bandwidth of an undirected graph.
 
-[TODO: Write here]
+Given an undirected, possibly weighted graph ``G`` and finite set of integers ``S`` ⊂ ``ℤ``,
+``G`` is said to be "``S``-diagonalizable" if there exists some diagonal matrix ``D`` and
+matrix ``P`` with all entries from ``S`` such that ``G``'s Laplacian matrix
+``L(G) = PDP⁻¹``. If ``G`` is ``S``-diagonalizable, then its "``S``-bandwidth" is the
+minimum integer ``k ∈ \\{1, 2, …, |V(G)|\\}`` such that there exists some diagonal matrix
+``D`` and matrix ``P`` with all entries from ``S`` such that ``L(G) = PDP⁻¹`` and
+``[PᵀP]ᵢⱼ = 0`` whenever ``|i - j| ≥ k``; otherwise, its ``S``-bandwidth is simply ``∞``.
+
+For specific choices of ``S`` (namely ``\\{-1, 1\\}`` and ``\\{-1, 0, 1\\}``), the
+``S``-bandwidth of a quantum network has been shown to be an indicator of high state
+transfer fidelity due to automorphic properties of the graph. As such, the nascent study of
+``S``-diagonalizability and ``S``-bandwidth is of interest in the broader context of quantum
+information theory.
+
+This package, therefore, implements the first algorithm beyond mere brute force to minimize
+the ``S``-bandwidth of an undirected graph with integer edge weights. Capabilities also
+exist for determining whether a graph has ``S``-bandwidth less than or equal to a fixed
+integer ``k ≥ 1`` without necessarily caring about the true minimum value.
+
+The full documentation is available at
+[GitHub Pages](https://graphquantum.github.io/SDiagonalizability.jl/).
 """
 module SDiagonalizability
 
-using Combinatorics
-using DataStructures
-using ElasticArrays
 using Graphs
 using LinearAlgebra
 using MatrixBandwidth
+
+using Combinatorics: combinations, multiset_permutations
+using DataStructures: OrderedDict, counter
+using ElasticArrays: ElasticMatrix
 using PrecompileTools: @setup_workload, @compile_workload
 
 include("utils.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -102,6 +102,9 @@ end
     SDiagonalizabilityResult{A,B,C} <: AbstractSDiagResult
 
 [TODO: Write here]
+
+# Supertype Hierarchy
+`SDiagonalizabilityResult` <: [`AbstractSDiagResult`](@ref)
 """
 struct SDiagonalizabilityResult{
     A<:Union{AbstractGraph,AbstractMatrix{<:Integer}},


### PR DESCRIPTION
Prepare for the first stable releasing, v0.1.0, by updating project metadata and fleshing out some documentation.