### PR TITLE
Add Markdown-style docstring refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added Markdown-style references (e.g., [^ABC]: ...) to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#47).
+
 ## [0.1.1] - 2025-08-05
 
 ### Changed

--- a/src/core.jl
+++ b/src/core.jl
@@ -9,6 +9,10 @@
     s_bandwidth(L::AbstractMatrix{<:Integer}, S) -> SBandMinimizationResult
 
 [TODO: Write here. Also, comment inline and cite [JP25](@cite).]
+
+# References
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
 """
 function s_bandwidth(g::AbstractGraph, S::Tuple{Vararg{Integer}})
     _assert_graph_has_defined_s_bandwidth(g)
@@ -76,6 +80,10 @@ end
     has_s_bandwidth_at_most_k(L::AbstractMatrix{<:Integer}, S, k) -> SBandRecognitionResult
 
 [TODO: Write here. Also, comment inline and cite [JP25](@cite).]
+
+# References
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
 """
 function has_s_bandwidth_at_most_k(g::AbstractGraph, S::Tuple{Vararg{Integer}}, k::Integer)
     _assert_graph_has_defined_s_bandwidth(g)

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -109,6 +109,10 @@ noting that eigenvector generation is one of two major bottlenecks in the overal
 *S*-bandwidth minimization algorithm. Given how much potential there is for optimization in
 this piece of code, we thus prioritize performance over readability in this particular case,
 making every effort to include inline comments wherever clarification may be needed.
+
+# References
+
+[^Slo25]: N. J. Sloane, *a(n) = (3^n - 1)/2*. Entry A003462 (2025). Accessed: 2025-05-22. https://oeis.org/A003462.
 """
 function _pot_kernel_01neg_eigvecs(n::Integer)
     # Cache to avoid redundant recomputations of the `leading` vector
@@ -204,6 +208,10 @@ noting that eigenvector generation is one of two major bottlenecks in the overal
 *S*-bandwidth minimization algorithm. Given how much potential there is for optimization in
 this piece of code, we thus prioritize performance over readability in this particular case,
 making every effort to include inline comments wherever clarification may be needed.
+
+# References
+
+[^Deu25]: E. Deutsch. *Number of humps in all Motzkin paths of length n*. Entry A097861 (2025). Accessed: 2025-05-22. https://oeis.org/A097861.
 """
 function _pot_nonkernel_01neg_eigvecs(n::Integer)
     # Caches to avoid redundant recomputations of the `leading` and `entries` vectors

--- a/src/factories/orthogonality_factory.jl
+++ b/src/factories/orthogonality_factory.jl
@@ -26,6 +26,12 @@ different depth-first search for each family of values of ``k`` on our "tree" of
 # Interface
 Concrete subtypes of `KOrthogonality` **must** implement the following fields:
 - `k::Int`: the ``k``-orthogonality parameter. Must be a positive integer.
+
+# References
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
+
+[^Maf14]: L. O. Mafteiu-Scai. *The Bandwidths of a Matrix. A Survey of Algorithms*. *Annals of West University of Timisoara - Mathematics and Computer Science* **52**, 183–223 (2014). https://doi.org/10.2478/awutm-2014-0019.
 """
 abstract type KOrthogonality end
 
@@ -71,6 +77,10 @@ equivalent to the vectors' Gram matrix being tridiagonal [JP25; p. 313](@cite).
 
 # Constructors
 - `QuasiOrthogonality()`: constructs a new `QuasiOrthogonality` object with `k = 2`.
+
+# References
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
 """
 struct QuasiOrthogonality <: KOrthogonality
     k::Int

--- a/src/laplacian_s_spectra.jl
+++ b/src/laplacian_s_spectra.jl
@@ -118,6 +118,14 @@ If an undirected graph with integer edge weights is ``\\{-1, 0, 1\\}``-diagonali
 more restrictively, ``\\{-1, 1\\}``-diagonalizable), then its Laplacian matrix has integer
 eigenvalues [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a
 useful screening step in this package's principal *S*-bandwidth minimization algorithm.
+
+# References
+
+[^Fox09]: J. Fox. *Lecture 19: The Petersen graph and Moore graphs*. Lecture notes, MAT 307: Combinatorics (2009). Accessed: 2025-07-25. https://math.mit.edu/~fox/MAT307.html.
+
+[^Joy15]: D. Joyce. *Rotations and complex eigenvalues*. Lecture notes, Math 130: Linear Algebra (2015). http://aleph0.clarku.edu/~ma130/complexeigen.pdf.
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
 """
 function check_spectrum_integrality(A::AbstractMatrix{<:Integer})
     A_copy = Matrix{Int}(A) # Avoid shared mutability and cast to `Matrix{Int}`

--- a/src/types.jl
+++ b/src/types.jl
@@ -175,6 +175,10 @@ If an undirected graph with integer edge weights is ``\\{-1, 0, 1\\}``-diagonali
 more restrictively, ``\\{-1, 1\\}``-diagonalizable), then its Laplacian matrix has integer
 eigenvalues [JP25; p. 312](@cite). Hence, validating Laplacian integrality serves as a
 useful screening step in this package's principal *S*-bandwidth minimization algorithm.
+
+# References
+
+[^JP25]: N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable graphs*. *Linear Algebra and its Applications* **704**, 309–39 (2025). https://doi.org/10.1016/j.laa.2024.10.016.
 """
 struct SpectrumIntegralResult{T<:Union{Nothing,OrderedDict{Int,Int}}}
     matrix::AbstractMatrix{<:Integer}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -75,9 +75,9 @@ julia> SDiagonalizability._extract_independent_cols(A)
 Since we already need a pivoted QR decomposition to identify independent columns of `A` (or,
 rather, to order the columns in such a way that the first `rank(A)` ones are guaranteed to
 be independent), it makes sense to use data from the resulting factorization object to
-compute the rank of `A` rather than compute a separate SVD. We thus count the nonzero scaling
-coefficients—that is, the diagonal entries of the `R` matrix in `A = QR`—to determine the
-rank, similarly to how we count the nonzero singular values in an SVD.
+compute the rank of `A` rather than compute a separate SVD. We thus count the nonzero
+scaling coefficients—that is, the diagonal entries of the `R` matrix in `A = QR`—to
+determine the rank, similarly to how we count the nonzero singular values in an SVD.
 
 It is worth noting that we manually specify a higher relative tolerance for this rank
 computation. Further discussion can be found in the [`_rank_rtol`](@ref) documentation, but
@@ -88,6 +88,12 @@ dealing with all ``\\{-1, 0, 1\\}``-eigenvectors of a Laplacian matrix, which is
 intended use case of this helper function in this package). Our replacement tolerance, on
 the other hand, is a widely accepted standard in numerical analysis which uses the maximum
 dimension instead [PTVF07; p. 795](@cite).
+
+# References
+
+[^BG65]: P. Businger and G. H. Golub. *Linear Least Squares Solutions by Householder Transformations*. *Numerische Mathematik* **7**, 269–76 (1965). https://doi.org/10.1007/BF01436084.
+
+[^PTVF07]: W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery. *Numerical Recipes: The Art of Scientific Computing*. 3rd Edition (Cambridge University Press, Cambridge, UK, 2007). ISBN: 978-0-521-88068-8. https://dl.acm.org/doi/10.5555/1403886.
 """
 function _extract_independent_cols(A::AbstractMatrix{<:Integer})
     F = qr(A, ColumnNorm())
@@ -204,6 +210,10 @@ At first blush, it may seem as though the choice of `DomainError` over something
 this is informed by the simple *ad hoc* use of this function to validate inputs for other
 functions requiring Laplacian matrices. Certainly, this function is never meant to be
 publicly exposed on its own.
+
+# References
+
+[^VL20]: J. J. Veerman and R. Lyons. *A Primer on Laplacian Dynamics in Directed Graphs*. *Nonlinear Phenomena in Complex Systems* **23**, 196–206 (2020). https://doi.org/10.33581/1561-4085-2020-23-2-196-206.
 """
 function _assert_matrix_is_undirected_laplacian(L::AbstractMatrix{<:Integer})
     if !issymmetric(L)
@@ -271,6 +281,16 @@ number (which determines how numerically stable SVD and QRD are) grows with both
 turn instead to the same relative tolerance used by NumPy's and MATLAB's rank
 functions—`max(m,n) * ϵ` [Num25, MAT25](@cite). (Indeed, this is a widely adopted standard
 across the field of numerical analysis [PTVF07; p. 795](@cite).)
+
+# References
+
+[^CD05]: Z. Chen and J. Dongarra. *Condition Numbers of Gaussian Random Matrices*. *SIAM Journal on Matrix Analysis and Applications* **27**, 603–20 (2005). https://doi.org/10.1137/040616413.
+
+[^MAT25]: MATLAB Developers, *rank*. MATLAB reference documentation – R2025a (2025). Accessed: 2025-05-29. https://www.mathworks.com/help/matlab/ref/rank.html.
+
+[^Num25]: NumPy Developers, *numpy.linalg.matrix_rank*. NumPy reference documentation – v2.2 (2025). Accessed: 2025-05-22. https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_rank.html.
+
+[^PTVF07]: W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery. *Numerical Recipes: The Art of Scientific Computing*. 3rd Edition (Cambridge University Press, Cambridge, UK, 2007). ISBN: 978-0-521-88068-8. https://dl.acm.org/doi/10.5555/1403886.
 """
 function _rank_rtol(A::AbstractMatrix{T}) where {T}
     return maximum(size(A)) * eps(LinearAlgebra.eigtype(T))


### PR DESCRIPTION
This PR adds Markdown-style references (e.g., [^ABC]: ...) to docstrings in new '**References**'  sections at the end for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website.

(Closes #44.)