### PR TITLE
Update docs for 'src/eigenvector_generation.jl'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#47, #48).
 
+### Changed
+
+- Made the return type of the `_pot_kernel_1neg_eigvecs` and `_pot_nonkernel_1neg_eigvecs` functions consistent regardless of the `n` parameter passed (#51).
+- Finished the docstrings for `src/eigenvector_generation.jl`, fixing some minor inaccuracies along the way (#51).
+
 ## [0.1.1] - 2025-08-05
 
 ### Changed

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -20,12 +20,12 @@
   url = {https://doi.org/10.1137/040616413}
 }
 
-@misc{Deu25,
+@misc{Deu21,
   author = {Deutsch, Emeric},
   institution = {The On-Line Encyclopedia of Integer Sequences},
   howpublished = {Entry A097861},
   title = {Number of humps in all Motzkin paths of length n},
-  year = {2025},
+  year = {2021},
   url = {https://oeis.org/A097861},
   note = {Accessed: 2025-05-22}
 }
@@ -99,14 +99,34 @@
   note = {ISBN: 978-0-521-88068-8}
 }
 
-@misc{Slo25,
+@misc{Slo10,
   author = {Sloane, Neil James Alexander},
   institution = {The On-Line Encyclopedia of Integer Sequences},
   howpublished = {Entry A003462},
   title = {a(n) = (3^n - 1)/2},
-  year = {2025},
+  year = {2010},
   url = {https://oeis.org/A003462},
   note = {Accessed: 2025-05-22}
+}
+
+@misc{Slo14,
+  author = {Sloane, Neil James Alexander},
+  institution = {The On-Line Encyclopedia of Integer Sequences},
+  howpublished = {A000079},
+  title = {Powers of 2: a(n) = 2^n},
+  year = {2014},
+  url = {https://oeis.org/A000079},
+  note = {Accessed: 2025-08-13},
+}
+
+@misc{Sut14,
+  author = {Sutherland, Andrew V.},
+  institution = {The On-Line Encyclopedia of Integer Sequences},
+  howpublished = {A138364},
+  title = {The number of Motzkin n-paths with exactly one flat step},
+  year = {2014},
+  url = {https://oeis.org/A138364},
+  note = {Accessed: 2025-08-13}
 }
 
 @article{VL20,

--- a/src/eigenvector_generation.jl
+++ b/src/eigenvector_generation.jl
@@ -5,21 +5,67 @@
 # distributed except according to those terms.
 
 """
-    pot_kernel_s_eigvecs(n, S) -> Iterators.Flatten{<:Base.Generator}
+    pot_kernel_s_eigvecs(n, S) -> Union{Base.Generator,Base.Iterators.Flatten{<:Base.Generator}}
 
-[TODO: Write here]
+Lazily compute all potential kernel `S`-eigenvectors of an `n×n` Laplacian.
+
+The only accepted values of `S` are `(-1, 0, 1)`, `(-1, 1)`, and permutations thereof (e.g.,
+`(1, -1, 0)`, which will be sorted internally to `(-1, 0, 1)` anyway), in line with the sets
+studied by [JP25].
+
+Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
+linear independence between all generated vectors.
 
 # Arguments
-[TODO: Write here]
+- `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
+    potential kernel `S`-eigenvectors.
+- `S::Tuple{Vararg{Integer}}`: the set of possible entries of the potential eigenvectors,
+    provided in the form of a tuple of unique `Integer`'s. Must be either `(-1, 0, 1)`,
+    `(-1, 1)`, or a permutation thereof.
 
 # Returns
-[TODO: Write here]
+- `gen::Union{Base.Generator,Base.Iterators.Flatten{<:Base.Generator}}`: a lazily evaluated
+    iterator over all `S`-vectors in ``ℝⁿ``, unique up to span. Eltype is `Vector{Int}`.
 
 # Throws
 - `DomainError`: if `n` is negative.
+- `ArgumentError`: if `S` is not `(-1, 0, 1)`, `(-1, 1)`, or a permutation thereof.
 
 # Examples
-[TODO: Write here]
+Generate all potential kernel ``\\{-1, 0, 1\\}``-eigenvectors of a ``4×4`` Laplacian matrix:
+```jldoctest
+julia> stack(SDiagonalizability.pot_kernel_s_eigvecs(4, (-1, 0, 1)))
+4×40 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1  …   0   0  0  0   0  0  0   0  0  0  0
+ -1  -1  -1  -1  -1  -1  -1  -1  -1      1   1  1  1   1  1  1   0  0  0  0
+ -1  -1  -1   0   0   0   1   1   1     -1   0  0  0   1  1  1   1  1  1  0
+ -1   0   1  -1   0   1  -1   0   1      1  -1  0  1  -1  0  1  -1  0  1  1
+```
+
+Generate all potential kernel ``\\{-1, 1\\}``-eigenvectors of a ``5×5`` Laplacian matrix,
+with the `S` set provided in a different order:
+```jldoctest
+julia> stack(SDiagonalizability.pot_kernel_s_eigvecs(5, (1, -1)))
+5×16 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1   1   1   1   1   1   1  1
+ -1  -1  -1  -1  -1  -1  -1  -1   1   1   1   1   1   1   1  1
+ -1  -1  -1  -1   1   1   1   1  -1  -1  -1  -1   1   1   1  1
+ -1  -1   1   1  -1  -1   1   1  -1  -1   1   1  -1  -1   1  1
+ -1   1  -1   1  -1   1  -1   1  -1   1  -1   1  -1   1  -1  1
+```
+
+Only the first two entry sets are supported, so the following command throws an error:
+```jldoctest
+julia> stack(SDiagonalizability.pot_kernel_s_eigvecs(6, (1, 2)))
+ERROR: ArgumentError: Unsupported entry set S: (1, 2)
+[...]
+```
+
+# References
+
+- [JP25](@cite): N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable
+    graphs*. Linear Algebra and its Applications **704**, 309–39 (2025).
+    https://doi.org/10.1016/j.laa.2024.10.016.
 """
 function pot_kernel_s_eigvecs(n::Integer, S::Tuple{Vararg{Integer}})
     if n < 0
@@ -40,21 +86,68 @@ function pot_kernel_s_eigvecs(n::Integer, S::Tuple{Vararg{Integer}})
 end
 
 """
-    pot_nonkernel_s_eigvecs(n, S) -> Iterators.Flatten{<:Base.Generator}
+    pot_nonkernel_s_eigvecs(n, S) -> Union{Base.Generator,Base.Iterators.Flatten{<:Base.Generator}}
 
-[TODO: Write here]
+Lazily compute all potential non-kernel `S`-eigenvectors of an `n×n` Laplacian.
+
+The only accepted values of `S` are `(-1, 0, 1)`, `(-1, 1)`, and permutations thereof (e.g.,
+`(1, -1, 0)`, which will be sorted internally to `(-1, 0, 1)` anyway), in line with the sets
+studied by [JP25].
 
 # Arguments
-[TODO: Write here]
+- `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
+    potential non-kernel `S`-eigenvectors.
+- `S::Tuple{Vararg{Integer}}`: the set of possible entries of the potential eigenvectors,
+    provided in the form of a tuple of unique `Integer`'s. Must be either `(-1, 0, 1)`,
+    `(-1, 1)`, or a permutation thereof.
 
 # Returns
-[TODO: Write here]
+- `gen::Union{Base.Generator,Base.Iterators.Flatten{<:Base.Generator}}`: a lazily evaluated
+    iterator over all `S`-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector, unique
+    up to span. Eltype is `Vector{Int}`.
 
 # Throws
 - `DomainError`: if `n` is negative.
+- `ArgumentError`: if `S` is not `(-1, 0, 1)`, `(-1, 1)`, or a permutation thereof.
 
 # Examples
-[TODO: Write here]
+Generate all potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors of a ``5×5`` Laplacian
+matrix, with the `S` set provided in a different order:
+```jldoctest
+julia> stack(SDiagonalizability.pot_nonkernel_s_eigvecs(5, (1, -1, 0)))
+5×25 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1  …   0   0   0   0   0   0   0   0   0
+ -1   0   0   0  -1  -1  -1  -1  -1      1   1   1   1   1   1   0   0   0
+  0  -1   0   0  -1  -1   0   0   1     -1   0   0  -1  -1   1   1   1   0
+  0   0  -1   0   0   1  -1   1  -1      0  -1   0  -1   1  -1  -1   0   1
+  0   0   0  -1   1   0   1  -1   0      0   0  -1   1  -1  -1   0  -1  -1
+```
+
+Generate all potential non-kernel ``\\{-1, 1\\}``-eigenvectors of a ``6×6`` Laplacian
+matrix:
+```jldoctest
+julia> stack(SDiagonalizability.pot_nonkernel_s_eigvecs(6, (-1, 1)))
+6×10 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1   1
+ -1  -1  -1  -1  -1  -1   1   1   1   1
+ -1  -1  -1   1   1   1  -1  -1  -1   1
+ -1   1   1  -1  -1   1  -1  -1   1  -1
+  1  -1   1  -1   1  -1  -1   1  -1  -1
+  1   1  -1   1  -1  -1   1  -1  -1  -1
+```
+
+Only the first two entry sets are supported, so the following command throws an error:
+```jldoctest
+julia> stack(SDiagonalizability.pot_nonkernel_s_eigvecs(7, (0, 3)))
+ERROR: ArgumentError: Unsupported entry set S: (0, 3)
+[...]
+```
+
+# References
+
+- [JP25](@cite): N. Johnston and S. Plosker. *Laplacian {−1,0,1}- and {−1,1}-diagonalizable
+    graphs*. Linear Algebra and its Applications **704**, 309–39 (2025).
+    https://doi.org/10.1016/j.laa.2024.10.016.
 """
 function pot_nonkernel_s_eigvecs(n::Integer, S::Tuple{Vararg{Integer}})
     if n < 0
@@ -77,23 +170,23 @@ end
 """
     _pot_kernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily compute all potential kernel ``\\{-1, 0 ,1\\}``-eigenvectors of an ``n×n`` Laplacian.
+Lazily compute all potential kernel ``\\{-1, 0 ,1\\}``-eigenvectors of an `n×n` Laplacian.
 
 Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
 linear independence between all generated vectors.
 
 # Arguments
 - `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
-    potential kernel eigenvectors.
+    potential kernel ``\\{-1, 0, 1\\}``-eigenvectors.
 
 # Returns
-- `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ``, unique up to span.
+- `::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over all
+    ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ``, unique up to span. Eltype is `Vector{Int}`.
 
 # Examples
-Generate all potential kernel eigenvectors for an order ``3`` Laplacian matrix:
+Generate all potential kernel ``\\{-1, 0, 1\\}``-eigenvectors of a ``3×3`` Laplacian matrix:
 ```jldoctest
-julia> hcat(SDiagonalizability._pot_kernel_01neg_eigvecs(3)...)
+julia> stack(SDiagonalizability._pot_kernel_01neg_eigvecs(3))
 3×13 Matrix{Int64}:
   1   1   1   1  1  1   1  1  1   0  0  0  0
  -1  -1  -1   0  0  0   1  1  1   1  1  1  0
@@ -101,8 +194,9 @@ julia> hcat(SDiagonalizability._pot_kernel_01neg_eigvecs(3)...)
 ```
 
 # Notes
-The number of potential kernel eigenvectors (unique up to span) for an order ``n`` Laplacian
-matrix is given by ``(3ⁿ - 1) / 2``. See also the relevant OEIS sequence [Slo25].
+The number of potential kernel ``\\{-1, 0, 1\\}``-eigenvectors (unique up to span) of an
+``n×n`` Laplacian matrix is equal to ``(3ⁿ - 1) / 2``. See also the relevant OEIS sequence
+[Slo10].
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
 noting that eigenvector generation is one of two major bottlenecks in the overall
@@ -112,7 +206,7 @@ making every effort to include inline comments wherever clarification may be nee
 
 # References
 
-- [Slo25](@cite): N. J. Sloane, *a(n) = (3^n - 1)/2*. Entry A003462 (2025). Accessed:
+- [Slo10](@cite): N. J. Sloane, *a(n) = (3^n - 1)/2*. Entry A003462 (2010). Accessed:
     2025-05-22. https://oeis.org/A003462.
 """
 function _pot_kernel_01neg_eigvecs(n::Integer)
@@ -148,21 +242,53 @@ end
 Base.eltype(::typeof(_pot_kernel_01neg_eigvecs(0))) = Vector{Int}
 
 """
-    _pot_kernel_1neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
+    _pot_kernel_1neg_eigvecs(n) -> Base.Generator
 
-[TODO: Write here. Also, comment inline]
+Lazily compute all potential kernel ``\\{-1, 1\\}``-eigenvectors of an `n×n` Laplacian.
+
+Each vector is normalized so that its first entry is ``1``, enforcing pairwise linear
+independence between all generated vectors.
+
+# Arguments
+- `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
+    potential kernel ``\\{-1, 1\\}``-eigenvectors.
+
+# Returns
+- `::Base.Generator`: a lazily evaluated iterator over all ``\\{-1, 1\\}``-vectors in
+    ``ℝⁿ``, unique up to span. Eltype is `Vector{Int}`.
+
+# Examples
+Generate all potential kernel ``\\{-1, 1\\}``-eigenvectors of a ``5×5`` Laplacian matrix:
+```jldoctest
+julia> stack(SDiagonalizability._pot_kernel_1neg_eigvecs(5))
+5×16 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1   1   1   1   1   1   1  1
+ -1  -1  -1  -1  -1  -1  -1  -1   1   1   1   1   1   1   1  1
+ -1  -1  -1  -1   1   1   1   1  -1  -1  -1  -1   1   1   1  1
+ -1  -1   1   1  -1  -1   1   1  -1  -1   1   1  -1  -1   1  1
+ -1   1  -1   1  -1   1  -1   1  -1   1  -1   1  -1   1  -1  1
+```
+
+# Notes
+The number of potential kernel ``\\{-1, 1\\}``-eigenvectors (unique up to span) of an
+``n×n`` Laplacian matrix is equal to ``0`` for ``n = 0`` and ``2ⁿ`` for ``n > 0``. See also
+the relevant OEIS sequence [Slo14] for the ``n > 0`` case.
+
+# References
+
+- [Slo14](@cite): N. J. Sloane, *Powers of 2: a(n) = 2^n*. Entry A000079 (2014). Accessed:
+    2025-08-13. https://oeis.org/A000079.
 """
 function _pot_kernel_1neg_eigvecs(n::Integer)
     if n == 0
-        gen = (Int[] for _ in 1:0)
+        entries = Int[]
     else
         entries = Vector{Int}(undef, 2(n - 1))
         entries[1:(n - 1)] .= -1
         entries[n:(2(n - 1))] .= 1
-        gen = (vcat(1, body) for body in multiset_permutations(entries, n - 1))
     end
 
-    return gen
+    return (vcat(1, body) for body in multiset_permutations(entries, n - 1))
 end
 
 # Specify the return type of the generator for type inference and stability
@@ -171,7 +297,7 @@ Base.eltype(::typeof(_pot_kernel_1neg_eigvecs(0))) = Vector{Int}
 """
     _pot_nonkernel_01neg_eigvecs(n) -> Iterators.Flatten{<:Base.Generator}
 
-Lazily compute all potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors of an ``n×n`` Laplacian.
+Lazily compute all potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors of an `n×n` Laplacian.
 
 Each vector is normalized so that its first nonzero entry is ``1``, enforcing pairwise
 linear independence between all generated vectors. Since all Laplacian matrices have
@@ -181,17 +307,18 @@ non-kernel ``\\{-1, 0, 1\\}``-eigenvector must also have an equal number of ``-1
 
 # Arguments
 - `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
-    potential non-kernel eigenvectors.
+    potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors.
 
 # Returns
-- `eigvec_generator::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over
-    all ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector,
-    unique up to span.
+- `::Iterators.Flatten{<:Base.Generator}`: a lazily evaluated iterator over all
+    ``\\{-1, 0, 1\\}``-vectors in ``ℝⁿ`` orthogonal to the all-ones kernel vector, unique up
+    to span. Eltype is `Vector{Int}`.
 
 # Examples
-Generate all potential non-kernel eigenvectors of an order ``4`` Laplacian matrix:
+Generate all potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors of a ``4×4`` Laplacian
+matrix:
 ```jldoctest
-julia> hcat(SDiagonalizability._pot_nonkernel_01neg_eigvecs(4)...)
+julia> stack(SDiagonalizability._pot_nonkernel_01neg_eigvecs(4))
 4×9 Matrix{Int64}:
   1   1   1   1   1   1   0   0   0
  -1   0   0  -1  -1   1   1   1   0
@@ -200,9 +327,9 @@ julia> hcat(SDiagonalizability._pot_nonkernel_01neg_eigvecs(4)...)
 ```
 
 # Notes
-The number of potential non-kernel eigenvectors (unique up to span) for an order ``n``
-Laplacian matrix is, by non-trivial combinatorial arguments, equal to the number of humps in
-all Motzkin paths of length ``n``. See also the relevant OEIS sequence [Deu25].
+The number of potential non-kernel ``\\{-1, 0, 1\\}``-eigenvectors (unique up to span) of an
+``n×n`` Laplacian matrix is, by non-trivial combinatorial arguments, equal to the number of
+humps in all Motzkin paths of length ``n``. See also the relevant OEIS sequence [Deu21].
 
 Regrettably, the implementation here is rather clunky and unidiomatic, but it is worth
 noting that eigenvector generation is one of two major bottlenecks in the overall
@@ -212,8 +339,8 @@ making every effort to include inline comments wherever clarification may be nee
 
 # References
 
-- [Deu25](@cite): E. Deutsch. *Number of humps in all Motzkin paths of length n*. Entry
-    A097861 (2025). Accessed: 2025-05-22. https://oeis.org/A097861.
+- [Deu21](@cite): E. Deutsch. *Number of humps in all Motzkin paths of length n*. Entry
+    A097861 (2021). Accessed: 2025-05-22. https://oeis.org/A097861.
 """
 function _pot_nonkernel_01neg_eigvecs(n::Integer)
     # Caches to avoid redundant recomputations of the `leading` and `entries` vectors
@@ -252,22 +379,62 @@ end
 Base.eltype(::typeof(_pot_nonkernel_01neg_eigvecs(0))) = Vector{Int}
 
 """
-    _pot_nonkernel_1neg_eigvecs(n)
+    _pot_nonkernel_1neg_eigvecs(n) -> Base.Generator
 
-[TODO: Write here. Also, comment inline]
+Lazily compute all potential non-kernel ``\\{-1, 1\\}``-eigenvectors of an `n×n` Laplacian.
+
+Each vector is normalized so that its first entry is ``1``, enforcing pairwise linear
+independence between all generated vectors. Since all Laplacian matrices have pairwise
+orthogonal eigenspaces and the all-ones vector is always in the kernel, every non-kernel
+``\\{-1, 1\\}``-eigenvector must half exactly `n / 2` ``-1``'s and `n / 2` ``1``'s. (As a
+direct corollary, if `n` is odd, an empty iterator is returned.)
+
+# Arguments
+- `n::Integer`: the order of the Laplacian matrix of some undirected graph for which to find
+    potential non-kernel ``\\{-1, 1\\}``-eigenvectors.
+
+# Returns
+- `::Base.Generator``: a lazily evaluated iterator over all ``\\{-1, 1\\}``-vectors in
+    ``ℝⁿ`` orthogonal to the all-ones kernel vector, unique up to span. Eltype is
+    `Vector{Int}`.
+
+# Examples
+Generate all potential non-kernel ``\\{-1, 1\\}``-eigenvectors of a ``6×6`` Laplacian
+matrix:
+```jldoctest
+julia> stack(SDiagonalizability._pot_nonkernel_1neg_eigvecs(6))
+6×10 Matrix{Int64}:
+  1   1   1   1   1   1   1   1   1   1
+ -1  -1  -1  -1  -1  -1   1   1   1   1
+ -1  -1  -1   1   1   1  -1  -1  -1   1
+ -1   1   1  -1  -1   1  -1  -1   1  -1
+  1  -1   1  -1   1  -1  -1   1  -1  -1
+  1   1  -1   1  -1  -1   1  -1  -1  -1
+```
+
+# Notes
+
+The number of potential non-kernel ``\\{-1, 1\\}``-eigenvectors (unique up to span) of an
+``n×n`` Laplacian matrix is equal to ``n`` for ``n ≤ 1`` and, by non-trivial combinatorial
+arguments, the number of Motzkin ``(n + 1)``-paths with exactly one flat step for ``n > 1``.
+See also the relevant OEIS sequence [Sut14] for the ``n > 1`` case.
+
+# References
+
+- [Sut14](@cite): A. V. Sutherland. *The number of Motzkin n-paths with exactly one flat
+    step*. Entry A138364 (2014). Accessed: 2025-08-13.
 """
 function _pot_nonkernel_1neg_eigvecs(n::Integer)
     if n == 0 || isodd(n)
-        gen = (Int[] for _ in 1:0)
+        entries = Int[]
     else
         entries = Vector{Int}(undef, n - 1)
         mid = div(n, 2)
         entries[1:mid] .= -1
         entries[(mid + 1):(n - 1)] .= 1
-        gen = (vcat(1, body) for body in multiset_permutations(entries, n - 1))
     end
 
-    return gen
+    return (vcat(1, body) for body in multiset_permutations(entries, n - 1))
 end
 
 # Specify the return type of the generator for type inference and stability


### PR DESCRIPTION
This PR finishes the incomplete documentation for 'src/eigenvector_generation.jl,' including fixing minor inaccuracies in existing docs.

It also makes the return types for the {-1,1}-eigenvectors more consistent regardless of the n parameter passed.