### PR TITLE
Reduce CI timeout-minute from 180 to 60

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
+    timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a typo in some comments in the *Aqua.jl* static analysis tests (#60).
+
 ## [0.1.2] - 2025-08-13
 
 ### Added

--- a/test/static_analysis/aqua.jl
+++ b/test/static_analysis/aqua.jl
@@ -26,8 +26,8 @@ using Aqua
         piracies=(; treat_as_own=[SDiagonalizability.LinearAlgebra.rank]),
         persistent_tasks=false, # Account for our manual definition of `LinearAlgebra.rank`
     )
-    #= We manually define the `LinearAlgebra.rank(::QRPivoted)` method, as it is not
-    available in Julua 1.11 and earlier. =#
+    #= We manually define the `LinearAlgebra.rank(::QRPivoted)` method when using a Julia
+    version below v1.12. =#
     @test length(Aqua.Piracy.hunt(SDiagonalizability)) <= 2
 end
 


### PR DESCRIPTION
This PR reduces the 'timeout-minutes' attribute in our CI.yml workflow from 180 to 60. It also fixes a typo in the Aqua.jl static analysis tests.